### PR TITLE
Enhance Create Budget Modal

### DIFF
--- a/components/budgets/BudgetStepsSidebar.tsx
+++ b/components/budgets/BudgetStepsSidebar.tsx
@@ -20,6 +20,11 @@ const steps = [
     description: "Income sources",
   },
   {
+    step: "cards" as StepType,
+    label: "Cards",
+    description: "Review budget cards",
+  },
+  {
     step: "categories" as StepType,
     label: "Categories",
     description: "Select categories",

--- a/components/budgets/CardsStep.tsx
+++ b/components/budgets/CardsStep.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { CreditCard, Info } from "lucide-react";
+import type { BudgetWithRelations } from "@/lib/types/budget";
+import { mapCardType } from "@/lib/utils/cards";
+
+interface CardsStepProps {
+  initialBudget?: BudgetWithRelations | null;
+  selectedCardIds: Set<string>;
+  onToggleCard: (cardId: string) => void;
+}
+
+export default function CardsStep({
+  initialBudget,
+  selectedCardIds,
+  onToggleCard,
+}: CardsStepProps) {
+  const cards = initialBudget?.cards ?? [];
+
+  const hasCards = cards.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-3 rounded-lg bg-blue-50 p-4 text-sm text-blue-800">
+        <Info className="mt-0.5 h-4 w-4 flex-shrink-0" />
+        <div>
+          <p className="font-medium">
+            Cards are optional and can be managed later.
+          </p>
+          <p className="mt-1 text-xs text-blue-900/80">
+            We&apos;ll always create a main debit card for your budget so income
+            has somewhere to land. You can add additional credit, debit, or cash
+            cards from the Cards tab after your budget is created.
+          </p>
+        </div>
+      </div>
+
+      {hasCards ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Cards that will be copied into this budget
+            </h3>
+            <p className="text-xs text-gray-500">
+              Uncheck any cards you don&apos;t want to duplicate.
+            </p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {cards.map((card) => (
+              <div
+                key={card.id}
+                className="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
+              >
+                <button
+                  type="button"
+                  onClick={() => onToggleCard(card.id)}
+                  className="mt-1 h-4 w-4 flex-shrink-0 rounded border border-gray-300 bg-white text-secondary focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-1"
+                  aria-pressed={selectedCardIds.has(card.id)}
+                >
+                  {selectedCardIds.has(card.id) && (
+                    <span className="block h-full w-full bg-secondary" />
+                  )}
+                </button>
+                <div className="flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">
+                        {card.name}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {mapCardType(card.cardType)}
+                      </p>
+                    </div>
+                    {card.spendingLimit != null && (
+                      <div className="text-right">
+                        <p className="text-xs text-gray-500">Limit</p>
+                        <p className="text-sm font-semibold text-gray-900">
+                          ${card.spendingLimit.toLocaleString()}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                  {card.user && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      Assigned to{" "}
+                      <span className="font-medium">
+                        {card.user.firstName && card.user.lastName
+                          ? `${card.user.firstName} ${card.user.lastName}`
+                          : card.user.name ?? "Unknown user"}
+                      </span>
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-white px-4 py-8 text-center">
+          <CreditCard className="mb-3 h-8 w-8 text-gray-300" />
+          <p className="text-sm font-medium text-gray-900">
+            No existing cards to copy
+          </p>
+          <p className="mt-1 max-w-sm text-xs text-gray-500">
+            We&apos;ll create a default debit card named &quot;Main&quot; for
+            this budget. You can add more cards from the Cards tab once the
+            budget is created.
+          </p>
+        </div>
+      )}
+
+      <p className="mt-2 text-xs text-gray-500">
+        When you click <span className="font-semibold">Continue</span>, you&apos;ll
+        move on without making any changes to cards. You can always adjust cards
+        later from the budget&apos;s Cards page.
+      </p>
+    </div>
+  );
+}
+

--- a/components/budgets/CardsStep.tsx
+++ b/components/budgets/CardsStep.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call */
 import { CreditCard, Info, Plus, Trash2 } from "lucide-react";
 import type { CardToInclude } from "./types";
 import { mapCardType } from "@/lib/utils/cards";

--- a/components/budgets/CardsStep.tsx
+++ b/components/budgets/CardsStep.tsx
@@ -1,23 +1,25 @@
 "use client";
 
-import { CreditCard, Info } from "lucide-react";
-import type { BudgetWithRelations } from "@/lib/types/budget";
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call */
+import { CreditCard, Info, Plus, Trash2 } from "lucide-react";
+import type { CardToInclude } from "./types";
 import { mapCardType } from "@/lib/utils/cards";
 
 interface CardsStepProps {
-  initialBudget?: BudgetWithRelations | null;
-  selectedCardIds: Set<string>;
-  onToggleCard: (cardId: string) => void;
+  cardsToInclude: CardToInclude[];
+  onRemoveCard: (id: string) => void;
+  onOpenAddCard?: () => void;
+  isDuplicating?: boolean;
 }
 
 export default function CardsStep({
-  initialBudget,
-  selectedCardIds,
-  onToggleCard,
+  cardsToInclude,
+  onRemoveCard,
+  onOpenAddCard,
+  isDuplicating = false,
 }: CardsStepProps) {
-  const cards = initialBudget?.cards ?? [];
-
-  const hasCards = cards.length > 0;
+  const list: CardToInclude[] = cardsToInclude;
+  const hasCards = list.length > 0;
 
   return (
     <div className="space-y-4">
@@ -29,8 +31,9 @@ export default function CardsStep({
           </p>
           <p className="mt-1 text-xs text-blue-900/80">
             We&apos;ll always create a main debit card for your budget so income
-            has somewhere to land. You can add additional credit, debit, or cash
-            cards from the Cards tab after your budget is created.
+            has somewhere to land. Add cards below or remove any you don&apos;t
+            want; you can also manage cards from the Cards tab after the budget
+            is created.
           </p>
         </div>
       </div>
@@ -39,29 +42,21 @@ export default function CardsStep({
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-semibold text-gray-900">
-              Cards that will be copied into this budget
+              {isDuplicating
+                ? "Cards to copy (remove any you don't want)"
+                : "Cards to add to this budget"}
             </h3>
-            <p className="text-xs text-gray-500">
-              Uncheck any cards you don&apos;t want to duplicate.
-            </p>
           </div>
           <div className="grid gap-3 md:grid-cols-2">
-            {cards.map((card) => (
+            {list.map((card) => (
               <div
                 key={card.id}
                 className="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
               >
-                <button
-                  type="button"
-                  onClick={() => onToggleCard(card.id)}
-                  className="mt-1 h-4 w-4 flex-shrink-0 rounded border border-gray-300 bg-white text-secondary focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-1"
-                  aria-pressed={selectedCardIds.has(card.id)}
-                >
-                  {selectedCardIds.has(card.id) && (
-                    <span className="block h-full w-full bg-secondary" />
-                  )}
-                </button>
-                <div className="flex-1">
+                <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-900 text-white">
+                  <CreditCard className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 flex-1">
                   <div className="flex items-center justify-between gap-2">
                     <div>
                       <p className="text-sm font-medium text-gray-900">
@@ -91,6 +86,15 @@ export default function CardsStep({
                     </p>
                   )}
                 </div>
+                <button
+                  type="button"
+                  onClick={() => onRemoveCard(card.id)}
+                  className="mt-0.5 flex-shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                  title="Remove card"
+                  aria-label={`Remove ${card.name}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
               </div>
             ))}
           </div>
@@ -99,22 +103,36 @@ export default function CardsStep({
         <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-white px-4 py-8 text-center">
           <CreditCard className="mb-3 h-8 w-8 text-gray-300" />
           <p className="text-sm font-medium text-gray-900">
-            No existing cards to copy
+            {isDuplicating
+              ? "No cards will be copied"
+              : "No cards added yet"}
           </p>
           <p className="mt-1 max-w-sm text-xs text-gray-500">
-            We&apos;ll create a default debit card named &quot;Main&quot; for
-            this budget. You can add more cards from the Cards tab once the
-            budget is created.
+            {isDuplicating
+              ? "Add new cards below or continue without copying any."
+              : "We'll create a default debit card named \"Main\". Add more below or continue."}
           </p>
+        </div>
+      )}
+
+      {onOpenAddCard && (
+        <div className="flex justify-center pt-2">
+          <button
+            type="button"
+            onClick={onOpenAddCard}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+          >
+            <Plus className="h-4 w-4" />
+            Add card
+          </button>
         </div>
       )}
 
       <p className="mt-2 text-xs text-gray-500">
         When you click <span className="font-semibold">Continue</span>, you&apos;ll
-        move on without making any changes to cards. You can always adjust cards
-        later from the budget&apos;s Cards page.
+        move on. You can always adjust cards later from the budget&apos;s Cards
+        page.
       </p>
     </div>
   );
 }
-

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,6 +13,7 @@ import {
   PeriodType,
   type CategoryType,
   TransactionType,
+  type CardType,
 } from "@prisma/client";
 import { calculateAdjustedIncome, calculateEndDate } from "@/lib/utils";
 
@@ -28,11 +30,13 @@ import type {
   CategoryAllocation,
   IncomeEntry,
   StepType,
+  CardToInclude,
 } from "./types";
 import type { BudgetWithRelations } from "@/lib/types/budget";
 import type { Budget } from "@prisma/client";
 import Button from "../Button";
 import { useCreateCard } from "@/lib/data-hooks/cards/useCards";
+import AddCardForm from "../cards/AddCardForm";
 
 // Validation schema
 const createBudgetSchema = z
@@ -151,9 +155,10 @@ export default function CreateBudgetModal({
     CategoryAllocation[]
   >([]);
   const [currentStep, setCurrentStep] = useState<StepType>("basic");
-  const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(
-    () => new Set<string>(),
-  );
+  const [cardsToInclude, setCardsToInclude] = useState<CardToInclude[]>([]);
+  const [showAddCardModal, setShowAddCardModal] = useState(false);
+  const [users, setUsers] = useState<Array<{ id: string; name: string; firstName: string; lastName: string; email: string | null; role: string }>>([]);
+  const [loadingUsers, setLoadingUsers] = useState(false);
   const [incomeEntries, setIncomeEntries] = useState<IncomeEntry[]>([
     {
       id: "1",
@@ -251,10 +256,17 @@ export default function CreateBudgetModal({
           setSelectedCategories([]);
         }
 
-        // Preselect all cards from the initial budget
-        const initialCardIds =
-          initialBudget.cards?.map((card) => card.id) ?? [];
-        setSelectedCardIds(new Set(initialCardIds));
+        // Start with all cards from the initial budget (user can remove with Delete)
+        const initialCards: CardToInclude[] =
+          initialBudget.cards?.map((card) => ({
+            id: card.id,
+            name: card.name,
+            cardType: card.cardType,
+            spendingLimit: card.spendingLimit ?? undefined,
+            userId: card.userId,
+            user: card.user ?? undefined,
+          })) ?? [];
+        setCardsToInclude(initialCards);
       } else {
         // Reset to defaults when opening without initial budget
         reset();
@@ -269,8 +281,17 @@ export default function CreateBudgetModal({
             frequency: PeriodType.MONTHLY,
           },
         ]);
-        setSelectedCardIds(new Set());
+        setCardsToInclude([]);
       }
+
+      setShowAddCardModal(false);
+      setLoadingUsers(true);
+      type UserRow = { id: string; name: string; firstName: string; lastName: string; email: string | null; role: string };
+      void fetch("/api/users")
+        .then(async (res) => (res.ok ? ((await res.json()) as UserRow[]) : []))
+        .then((data) => setUsers(Array.isArray(data) ? data : []))
+        .catch(() => setUsers([]))
+        .finally(() => setLoadingUsers(false));
     }
   }, [initialBudget, isOpen, setValue, reset]);
 
@@ -339,10 +360,9 @@ export default function CreateBudgetModal({
     }
   };
 
-  // Start with no categories selected
+  // Start with no categories selected (run once on mount)
   useEffect(() => {
     setSelectedCategories([]);
-    setSelectedCardIds(new Set());
   }, []);
 
   const handleAddCategory = (category: {
@@ -399,8 +419,9 @@ export default function CreateBudgetModal({
 
   const resetModal = () => {
     reset();
-    // Reset categories to empty
     setSelectedCategories([]);
+    setCardsToInclude([]);
+    setShowAddCardModal(false);
     setIncomeEntries([
       {
         id: "1",
@@ -452,16 +473,36 @@ export default function CreateBudgetModal({
     );
   };
 
-  const handleToggleCard = (cardId: string) => {
-    setSelectedCardIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(cardId)) {
-        next.delete(cardId);
-      } else {
-        next.add(cardId);
-      }
-      return next;
-    });
+  const handleRemoveCard = (id: string) => {
+    setCardsToInclude((prev) => prev.filter((c: CardToInclude) => c.id !== id));
+  };
+
+  const handleAddCard = (data: {
+    name: string;
+    cardType: CardType;
+    spendingLimit?: string;
+    userId: string;
+  }) => {
+    const user = users.find((u) => u.id === data.userId);
+    const newCard: CardToInclude = {
+      id: `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      name: data.name,
+      cardType: data.cardType,
+      spendingLimit:
+        data.spendingLimit && data.spendingLimit.trim() !== ""
+          ? Number(data.spendingLimit)
+          : undefined,
+      userId: data.userId,
+      user: user
+        ? {
+            name: user.name,
+            firstName: user.firstName,
+            lastName: user.lastName,
+          }
+        : undefined,
+    };
+    setCardsToInclude((prev) => [...prev, newCard]);
+    setShowAddCardModal(false);
   };
 
   const onSubmit = async (data: CreateBudgetFormData) => {
@@ -488,30 +529,20 @@ export default function CreateBudgetModal({
         incomes,
       })) as { message: string; budget: Budget };
 
-      // If duplicating from an existing budget and the user selected cards, copy only selected cards
-      if (initialBudget && selectedCardIds.size > 0) {
-        const newBudgetId: string = created.budget.id;
-
-        if (newBudgetId) {
-          const cardsToCopy =
-            initialBudget.cards?.filter((card) =>
-              selectedCardIds.has(card.id),
-            ) ?? [];
-
-          // Fire off card creations sequentially to keep it simple
-          // Errors here shouldn't block the budget itself from existing
-          for (const card of cardsToCopy) {
-            try {
-              await createCardMutation.mutateAsync({
-                name: card.name,
-                cardType: card.cardType,
-                spendingLimit: card.spendingLimit ?? undefined,
-                userId: card.userId,
-                budgetId: newBudgetId,
-              });
-            } catch {
-              // Ignore individual card copy failures; budget has already been created
-            }
+      // Create any cards the user added or chose to copy (from cardsToInclude)
+      const newBudgetId = created.budget.id;
+      if (cardsToInclude.length > 0 && newBudgetId) {
+        for (const card of cardsToInclude) {
+          try {
+            await createCardMutation.mutateAsync({
+              name: card.name,
+              cardType: card.cardType,
+              spendingLimit: card.spendingLimit,
+              userId: card.userId,
+              budgetId: newBudgetId,
+            });
+          } catch {
+            // Ignore individual card failures; budget has already been created
           }
         }
       }
@@ -656,9 +687,10 @@ export default function CreateBudgetModal({
 
                 {currentStep === "cards" && (
                   <CardsStep
-                    initialBudget={initialBudget}
-                    selectedCardIds={selectedCardIds}
-                    onToggleCard={handleToggleCard}
+                    cardsToInclude={cardsToInclude}
+                    onRemoveCard={handleRemoveCard}
+                    onOpenAddCard={() => setShowAddCardModal(true)}
+                    isDuplicating={!!initialBudget}
                   />
                 )}
 
@@ -739,6 +771,27 @@ export default function CreateBudgetModal({
           </div>
         </div>
       </div>
+
+      {/* Add card modal (within create budget flow) */}
+      {showAddCardModal && (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setShowAddCardModal(false)}
+        >
+          <div onClick={(e) => e.stopPropagation()} className="w-full max-w-md">
+            <AddCardForm
+              onSubmit={handleAddCard}
+              onCancel={() => setShowAddCardModal(false)}
+              isLoading={false}
+              users={users}
+              loadingUsers={loadingUsers}
+              defaultValues={{
+                userId: users.length === 1 ? users[0]?.id : undefined,
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -587,33 +587,29 @@ export default function CreateBudgetModal({
             toast.error(
               "Budget created, but income transactions could not be linked because no debit card was created successfully."
             );
-          }
-
-          const failedIncomes: string[] = [];
-          for (const income of incomes) {
-            try {
-              await createTransactionMutation.mutateAsync({
-                name: income.source,
-                description: income.description,
-                amount: income.amount,
-                budgetId: newBudgetId,
-                cardId: debitCardToUse?.id,
-                transactionType: TransactionType.INCOME,
-                occurredAt: new Date(),
-              });
-            } catch {
-              failedIncomes.push(income.source);
+          } else {
+            const failedIncomes: string[] = [];
+            for (const income of incomes) {
+              try {
+                await createTransactionMutation.mutateAsync({
+                  name: income.source,
+                  description: income.description,
+                  amount: income.amount,
+                  budgetId: newBudgetId,
+                  cardId: debitCardToUse.id,
+                  transactionType: TransactionType.INCOME,
+                  occurredAt: new Date(),
+                });
+              } catch {
+                failedIncomes.push(income.source);
+              }
             }
-          }
 
-          if (failedIncomes.length > 0) {
-            toast.error(
-              `Budget created, but ${failedIncomes.length} income transaction(s) could not be created: ${failedIncomes.join(", ")}`
-            );
-          } else if (!debitCardToUse) {
-            toast.error(
-              "INCOME transactions were created without a linked debit card. You can fix the card mapping in Transactions."
-            );
+            if (failedIncomes.length > 0) {
+              toast.error(
+                `Budget created, but ${failedIncomes.length} income transaction(s) could not be created: ${failedIncomes.join(", ")}`
+              );
+            }
           }
         }
       }

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -544,6 +544,7 @@ export default function CreateBudgetModal({
       
       if (cardsToInclude.length > 0 && newBudgetId) {
         const createdCards: Array<{ id: string; name: string; cardType: CardType }> = [];
+        const failedCards: string[] = [];
         for (const card of cardsToInclude) {
           try {
             const createdCard = await createCardMutation.mutateAsync({
@@ -560,8 +561,14 @@ export default function CreateBudgetModal({
               cardType: createdCard.cardType,
             });
           } catch {
-            // Ignore individual card failures; budget has already been created
+            failedCards.push(card.name);
           }
+        }
+
+        if (failedCards.length > 0) {
+          toast.error(
+            `Budget created, but ${failedCards.length} card(s) could not be added: ${failedCards.join(", ")}`,
+          );
         }
 
         // If we skipped creating the default debit card at budget-creation time,

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -12,7 +12,7 @@ import {
   PeriodType,
   type CategoryType,
   TransactionType,
-  type CardType,
+  CardType,
 } from "@prisma/client";
 import { calculateAdjustedIncome, calculateEndDate } from "@/lib/utils";
 
@@ -32,10 +32,10 @@ import type {
   CardToInclude,
 } from "./types";
 import type { BudgetWithRelations } from "@/lib/types/budget";
-import type { Budget } from "@prisma/client";
 import Button from "../Button";
 import { useCreateCard } from "@/lib/data-hooks/cards/useCards";
 import AddCardForm from "../cards/AddCardForm";
+import { useUpdateTransaction } from "@/lib/data-hooks/transactions/useTransactions";
 
 // Validation schema
 const createBudgetSchema = z
@@ -150,6 +150,7 @@ export default function CreateBudgetModal({
 }: CreateBudgetModalProps) {
   const createBudgetMutation = useCreateBudget();
   const createCardMutation = useCreateCard();
+  const updateTransactionMutation = useUpdateTransaction();
   const [selectedCategories, setSelectedCategories] = useState<
     CategoryAllocation[]
   >([]);
@@ -513,6 +514,15 @@ export default function CreateBudgetModal({
         allocatedAmount: cat.allocatedAmount,
       }));
 
+      // If we're duplicating and there is at least one debit card in the copy/add set,
+      // we should not auto-create the default "Main" debit card for the new budget.
+      const hasDebitCardsToCopy = cardsToInclude.some(
+        (card) =>
+          card.cardType === CardType.DEBIT ||
+          card.cardType === CardType.BUSINESS_DEBIT,
+      );
+      const shouldCreateDefaultDebitCard = !hasDebitCardsToCopy;
+
       // Convert income entries to the format expected by the API
       const incomes = incomeEntries.map((entry) => ({
         amount: entry.amount,
@@ -522,26 +532,79 @@ export default function CreateBudgetModal({
         frequency: entry.frequency,
       }));
 
-      const created = (await createBudgetMutation.mutateAsync({
+      const created = await createBudgetMutation.mutateAsync({
         ...data,
         categoryAllocations,
         incomes,
-      })) as { message: string; budget: Budget };
+        shouldCreateDefaultDebitCard,
+      });
 
       // Create any cards the user added or chose to copy (from cardsToInclude)
       const newBudgetId = created.budget.id;
+      
       if (cardsToInclude.length > 0 && newBudgetId) {
+        const createdCards: Array<{ id: string; name: string; cardType: CardType }> = [];
         for (const card of cardsToInclude) {
           try {
-            await createCardMutation.mutateAsync({
+            const createdCard = await createCardMutation.mutateAsync({
               name: card.name,
               cardType: card.cardType,
               spendingLimit: card.spendingLimit,
               userId: card.userId,
               budgetId: newBudgetId,
             });
+
+            createdCards.push({
+              id: createdCard.id,
+              name: createdCard.name,
+              cardType: createdCard.cardType,
+            });
           } catch {
             // Ignore individual card failures; budget has already been created
+          }
+        }
+
+        // If we skipped creating the default debit card at budget-creation time,
+        // re-link any INCOME transactions (created with no cardId) to the copied debit card.
+        if (!shouldCreateDefaultDebitCard) {
+          try {
+            const res = await fetch(`/api/budgets/${newBudgetId}/transactions`);
+            const transactions = (await res.json()) as Array<{
+              id: string;
+              transactionType: string;
+              cardId: string | null;
+            }>;
+
+            const debitCards = createdCards.filter(
+              (c) =>
+                c.cardType === CardType.DEBIT ||
+                c.cardType === CardType.BUSINESS_DEBIT,
+            );
+
+            const debitCardToUse =
+              debitCards.find((c) => c.name === "Main") ?? debitCards[0];
+
+            if (debitCardToUse) {
+              await Promise.all(
+                transactions
+                  .filter(
+                    (t) =>
+                      t.transactionType === TransactionType.INCOME &&
+                      !t.cardId,
+                  )
+                  .map((t) =>
+                    updateTransactionMutation.mutateAsync({
+                      id: t.id,
+                      data: {
+                        cardId: debitCardToUse.id,
+                        budgetId: newBudgetId,
+                      },
+                    }),
+                  ),
+              );
+            }
+          } catch {
+            // Non-fatal: budget + cards are already created; income linkage will be corrected manually.
           }
         }
       }

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -6,13 +6,16 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { X } from "lucide-react";
 import { toast } from "react-hot-toast";
-import { useCreateBudget } from "@/lib/data-hooks/budgets/useBudgets";
+import {
+  useCreateBudgetFromScratchWithCards,
+  useDuplicateBudgetWithCards,
+} from "@/lib/data-hooks/budgets/useBudgets";
 import {
   StrategyType,
   PeriodType,
   type CategoryType,
   TransactionType,
-  CardType,
+  type CardType,
 } from "@prisma/client";
 import { calculateAdjustedIncome, calculateEndDate } from "@/lib/utils";
 
@@ -33,9 +36,7 @@ import type {
 } from "./types";
 import type { BudgetWithRelations } from "@/lib/types/budget";
 import Button from "../Button";
-import { useCreateCard } from "@/lib/data-hooks/cards/useCards";
 import AddCardForm from "../cards/AddCardForm";
-import { useCreateTransaction } from "@/lib/data-hooks/transactions/useTransactions";
 
 // Validation schema
 const createBudgetSchema = z
@@ -148,9 +149,10 @@ export default function CreateBudgetModal({
   onSuccess,
   initialBudget,
 }: CreateBudgetModalProps) {
-  const createBudgetMutation = useCreateBudget();
-  const createCardMutation = useCreateCard();
-  const createTransactionMutation = useCreateTransaction();
+  const createBudgetFromScratchMutation = useCreateBudgetFromScratchWithCards();
+  const duplicateBudgetMutation = useDuplicateBudgetWithCards();
+  const isCreating =
+    createBudgetFromScratchMutation.isPending || duplicateBudgetMutation.isPending;
   const [selectedCategories, setSelectedCategories] = useState<
     CategoryAllocation[]
   >([]);
@@ -514,16 +516,6 @@ export default function CreateBudgetModal({
         allocatedAmount: cat.allocatedAmount,
       }));
 
-      // If we're duplicating and there is at least one debit card in the copy/add set,
-      // we should not auto-create the default "Main" debit card for the new budget.
-      const hasDebitCardsToCopy = cardsToInclude.some(
-        (card) =>
-          card.cardType === CardType.DEBIT ||
-          card.cardType === CardType.BUSINESS_DEBIT,
-      );
-      const shouldCreateDefaultDebitCard = !hasDebitCardsToCopy;
-
-      // Convert income entries to the format expected by the API
       const incomes = incomeEntries.map((entry) => ({
         amount: entry.amount,
         source: entry.source,
@@ -532,86 +524,35 @@ export default function CreateBudgetModal({
         frequency: entry.frequency,
       }));
 
-      const created = await createBudgetMutation.mutateAsync({
+      const cardsPayload = cardsToInclude.map((card) => ({
+        name: card.name,
+        cardType: card.cardType,
+        spendingLimit: card.spendingLimit,
+        userId: card.userId,
+      }));
+
+      const mutation = initialBudget ? duplicateBudgetMutation : createBudgetFromScratchMutation;
+      const created = await mutation.mutateAsync({
         ...data,
         categoryAllocations,
-        incomes: shouldCreateDefaultDebitCard ? incomes : undefined,
-        shouldCreateDefaultDebitCard,
+        incomes,
+        cardsToInclude: cardsPayload,
       });
 
-      // Create any cards the user added or chose to copy (from cardsToInclude)
-      const newBudgetId = created.budget.id;
-      
-      if (cardsToInclude.length > 0 && newBudgetId) {
-        const createdCards: Array<{ id: string; name: string; cardType: CardType }> = [];
-        const failedCards: string[] = [];
-        for (const card of cardsToInclude) {
-          try {
-            const createdCard = await createCardMutation.mutateAsync({
-              name: card.name,
-              cardType: card.cardType,
-              spendingLimit: card.spendingLimit,
-              userId: card.userId,
-              budgetId: newBudgetId,
-            });
+      if (created.failedCards.length > 0) {
+        toast.error(
+          `Budget created, but ${created.failedCards.length} card(s) could not be added: ${created.failedCards.join(", ")}`
+        );
+      }
 
-            createdCards.push({
-              id: createdCard.id,
-              name: createdCard.name,
-              cardType: createdCard.cardType,
-            });
-          } catch {
-            failedCards.push(card.name);
-          }
-        }
+      if (created.incomesSkipped && created.failedCards.length > 0) {
+        toast.error("Income transactions were skipped because card creation/copying failed.");
+      }
 
-        if (failedCards.length > 0) {
-          toast.error(
-            `Budget created, but ${failedCards.length} card(s) could not be added: ${failedCards.join(", ")}`,
-          );
-        }
-
-        // If we skipped creating the default debit card at budget-creation time,
-        // create/link INCOME transactions only after the debit cards exist.
-        if (!shouldCreateDefaultDebitCard) {
-          const debitCards = createdCards.filter(
-            (c) =>
-              c.cardType === CardType.DEBIT ||
-              c.cardType === CardType.BUSINESS_DEBIT,
-          );
-
-          const debitCardToUse =
-            debitCards.find((c) => c.name === "Main") ?? debitCards[0];
-
-          if (!debitCardToUse) {
-            toast.error(
-              "Budget created, but income transactions could not be linked because no debit card was created successfully."
-            );
-          } else {
-            const failedIncomes: string[] = [];
-            for (const income of incomes) {
-              try {
-                await createTransactionMutation.mutateAsync({
-                  name: income.source,
-                  description: income.description,
-                  amount: income.amount,
-                  budgetId: newBudgetId,
-                  cardId: debitCardToUse.id,
-                  transactionType: TransactionType.INCOME,
-                  occurredAt: new Date(),
-                });
-              } catch {
-                failedIncomes.push(income.source);
-              }
-            }
-
-            if (failedIncomes.length > 0) {
-              toast.error(
-                `Budget created, but ${failedIncomes.length} income transaction(s) could not be created: ${failedIncomes.join(", ")}`
-              );
-            }
-          }
-        }
+      if (created.failedIncomes.length > 0) {
+        toast.error(
+          `Budget created, but ${created.failedIncomes.length} income transaction(s) could not be created: ${created.failedIncomes.join(", ")}`
+        );
       }
 
       resetModal();
@@ -814,11 +755,11 @@ export default function CreateBudgetModal({
                 <Button
                   type="submit"
                   disabled={
-                    createBudgetMutation.isPending || !isAllocationStepValid()
+                    isCreating || !isAllocationStepValid()
                   }
                   onClick={handleSubmit(onSubmit)}
                 >
-                  {createBudgetMutation.isPending
+                  {isCreating
                     ? "Creating..."
                     : "Create Budget"}
                 </Button>

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -19,6 +19,7 @@ import { calculateAdjustedIncome, calculateEndDate } from "@/lib/utils";
 import BudgetStepsSidebar from "./BudgetStepsSidebar";
 import BasicBudgetStep from "./BasicBudgetStep";
 import IncomeStep from "./IncomeStep";
+import CardsStep from "./CardsStep";
 import CategoriesStep from "./CategoriesStep";
 import AllocationStep from "./AllocationStep";
 import PercentageAllocationStep from "./PercentageAllocationStep";
@@ -29,7 +30,9 @@ import type {
   StepType,
 } from "./types";
 import type { BudgetWithRelations } from "@/lib/types/budget";
+import type { Budget } from "@prisma/client";
 import Button from "../Button";
+import { useCreateCard } from "@/lib/data-hooks/cards/useCards";
 
 // Validation schema
 const createBudgetSchema = z
@@ -143,10 +146,14 @@ export default function CreateBudgetModal({
   initialBudget,
 }: CreateBudgetModalProps) {
   const createBudgetMutation = useCreateBudget();
+  const createCardMutation = useCreateCard();
   const [selectedCategories, setSelectedCategories] = useState<
     CategoryAllocation[]
   >([]);
   const [currentStep, setCurrentStep] = useState<StepType>("basic");
+  const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
   const [incomeEntries, setIncomeEntries] = useState<IncomeEntry[]>([
     {
       id: "1",
@@ -243,6 +250,11 @@ export default function CreateBudgetModal({
         } else {
           setSelectedCategories([]);
         }
+
+        // Preselect all cards from the initial budget
+        const initialCardIds =
+          initialBudget.cards?.map((card) => card.id) ?? [];
+        setSelectedCardIds(new Set(initialCardIds));
       } else {
         // Reset to defaults when opening without initial budget
         reset();
@@ -257,6 +269,7 @@ export default function CreateBudgetModal({
             frequency: PeriodType.MONTHLY,
           },
         ]);
+        setSelectedCardIds(new Set());
       }
     }
   }, [initialBudget, isOpen, setValue, reset]);
@@ -329,6 +342,7 @@ export default function CreateBudgetModal({
   // Start with no categories selected
   useEffect(() => {
     setSelectedCategories([]);
+    setSelectedCardIds(new Set());
   }, []);
 
   const handleAddCategory = (category: {
@@ -366,7 +380,8 @@ export default function CreateBudgetModal({
 
   const handleNext = () => {
     if (currentStep === "basic") setCurrentStep("income");
-    else if (currentStep === "income") setCurrentStep("categories");
+    else if (currentStep === "income") setCurrentStep("cards");
+    else if (currentStep === "cards") setCurrentStep("categories");
     else if (currentStep === "categories") setCurrentStep("allocation");
   };
 
@@ -377,7 +392,8 @@ export default function CreateBudgetModal({
 
   const handleBack = () => {
     if (currentStep === "income") setCurrentStep("basic");
-    else if (currentStep === "categories") setCurrentStep("income");
+    else if (currentStep === "cards") setCurrentStep("income");
+    else if (currentStep === "categories") setCurrentStep("cards");
     else if (currentStep === "allocation") setCurrentStep("categories");
   };
 
@@ -436,6 +452,18 @@ export default function CreateBudgetModal({
     );
   };
 
+  const handleToggleCard = (cardId: string) => {
+    setSelectedCardIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(cardId)) {
+        next.delete(cardId);
+      } else {
+        next.add(cardId);
+      }
+      return next;
+    });
+  };
+
   const onSubmit = async (data: CreateBudgetFormData) => {
     try {
       // Transform selectedCategories to the format expected by the API
@@ -454,11 +482,39 @@ export default function CreateBudgetModal({
         frequency: entry.frequency,
       }));
 
-      await createBudgetMutation.mutateAsync({
+      const created = (await createBudgetMutation.mutateAsync({
         ...data,
         categoryAllocations,
         incomes,
-      });
+      })) as { message: string; budget: Budget };
+
+      // If duplicating from an existing budget and the user selected cards, copy only selected cards
+      if (initialBudget && selectedCardIds.size > 0) {
+        const newBudgetId: string = created.budget.id;
+
+        if (newBudgetId) {
+          const cardsToCopy =
+            initialBudget.cards?.filter((card) =>
+              selectedCardIds.has(card.id),
+            ) ?? [];
+
+          // Fire off card creations sequentially to keep it simple
+          // Errors here shouldn't block the budget itself from existing
+          for (const card of cardsToCopy) {
+            try {
+              await createCardMutation.mutateAsync({
+                name: card.name,
+                cardType: card.cardType,
+                spendingLimit: card.spendingLimit ?? undefined,
+                userId: card.userId,
+                budgetId: newBudgetId,
+              });
+            } catch {
+              // Ignore individual card copy failures; budget has already been created
+            }
+          }
+        }
+      }
 
       resetModal();
       onSuccess?.();
@@ -527,11 +583,13 @@ export default function CreateBudgetModal({
         <div className="flex flex-shrink-0 items-center justify-between border-b p-6">
           <div>
             <h2 className="text-xl font-semibold text-gray-900">
-              Create New Budget
+              {initialBudget ? "Duplicate Budget" : "Create New Budget"}
             </h2>
             <p className="text-sm text-gray-500">
               {currentStep === "basic" && "Set up your budget basics"}
               {currentStep === "income" && "Set up your income"}
+              {currentStep === "cards" &&
+                "Optionally review the cards that will be associated with this budget. You can always adjust cards later from the Cards page."}
               {currentStep === "categories" &&
                 "Create your own spending categories (optional). You can organize them by needs, wants, or investments."}
               {currentStep === "allocation" &&
@@ -553,7 +611,13 @@ export default function CreateBudgetModal({
             currentStep={currentStep}
             onStepClick={(step) => {
               // Only allow navigation to completed steps or current step
-              const stepOrder = ["basic", "income", "categories", "allocation"];
+              const stepOrder = [
+                "basic",
+                "income",
+                "cards",
+                "categories",
+                "allocation",
+              ];
               const currentIndex = stepOrder.indexOf(currentStep);
               const targetIndex = stepOrder.indexOf(step);
               if (targetIndex <= currentIndex) {
@@ -587,6 +651,14 @@ export default function CreateBudgetModal({
                     onAddIncomeEntry={addIncomeEntry}
                     onRemoveIncomeEntry={removeIncomeEntry}
                     onUpdateIncomeEntry={updateIncomeEntry}
+                  />
+                )}
+
+                {currentStep === "cards" && (
+                  <CardsStep
+                    initialBudget={initialBudget}
+                    selectedCardIds={selectedCardIds}
+                    onToggleCard={handleToggleCard}
                   />
                 )}
 
@@ -660,7 +732,7 @@ export default function CreateBudgetModal({
                     (currentStep === "categories" && !isCategoriesStepValid())
                   }
                 >
-                  Next
+                  {currentStep === "cards" ? "Continue" : "Next"}
                 </Button>
               )}
             </div>

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/components/budgets/CreateBudgetModal.tsx
+++ b/components/budgets/CreateBudgetModal.tsx
@@ -35,7 +35,7 @@ import type { BudgetWithRelations } from "@/lib/types/budget";
 import Button from "../Button";
 import { useCreateCard } from "@/lib/data-hooks/cards/useCards";
 import AddCardForm from "../cards/AddCardForm";
-import { useUpdateTransaction } from "@/lib/data-hooks/transactions/useTransactions";
+import { useCreateTransaction } from "@/lib/data-hooks/transactions/useTransactions";
 
 // Validation schema
 const createBudgetSchema = z
@@ -150,7 +150,7 @@ export default function CreateBudgetModal({
 }: CreateBudgetModalProps) {
   const createBudgetMutation = useCreateBudget();
   const createCardMutation = useCreateCard();
-  const updateTransactionMutation = useUpdateTransaction();
+  const createTransactionMutation = useCreateTransaction();
   const [selectedCategories, setSelectedCategories] = useState<
     CategoryAllocation[]
   >([]);
@@ -535,7 +535,7 @@ export default function CreateBudgetModal({
       const created = await createBudgetMutation.mutateAsync({
         ...data,
         categoryAllocations,
-        incomes,
+        incomes: shouldCreateDefaultDebitCard ? incomes : undefined,
         shouldCreateDefaultDebitCard,
       });
 
@@ -572,46 +572,48 @@ export default function CreateBudgetModal({
         }
 
         // If we skipped creating the default debit card at budget-creation time,
-        // re-link any INCOME transactions (created with no cardId) to the copied debit card.
+        // create/link INCOME transactions only after the debit cards exist.
         if (!shouldCreateDefaultDebitCard) {
-          try {
-            const res = await fetch(`/api/budgets/${newBudgetId}/transactions`);
-            const transactions = (await res.json()) as Array<{
-              id: string;
-              transactionType: string;
-              cardId: string | null;
-            }>;
+          const debitCards = createdCards.filter(
+            (c) =>
+              c.cardType === CardType.DEBIT ||
+              c.cardType === CardType.BUSINESS_DEBIT,
+          );
 
-            const debitCards = createdCards.filter(
-              (c) =>
-                c.cardType === CardType.DEBIT ||
-                c.cardType === CardType.BUSINESS_DEBIT,
+          const debitCardToUse =
+            debitCards.find((c) => c.name === "Main") ?? debitCards[0];
+
+          if (!debitCardToUse) {
+            toast.error(
+              "Budget created, but income transactions could not be linked because no debit card was created successfully."
             );
+          }
 
-            const debitCardToUse =
-              debitCards.find((c) => c.name === "Main") ?? debitCards[0];
-
-            if (debitCardToUse) {
-              await Promise.all(
-                transactions
-                  .filter(
-                    (t) =>
-                      t.transactionType === TransactionType.INCOME &&
-                      !t.cardId,
-                  )
-                  .map((t) =>
-                    updateTransactionMutation.mutateAsync({
-                      id: t.id,
-                      data: {
-                        cardId: debitCardToUse.id,
-                        budgetId: newBudgetId,
-                      },
-                    }),
-                  ),
-              );
+          const failedIncomes: string[] = [];
+          for (const income of incomes) {
+            try {
+              await createTransactionMutation.mutateAsync({
+                name: income.source,
+                description: income.description,
+                amount: income.amount,
+                budgetId: newBudgetId,
+                cardId: debitCardToUse?.id,
+                transactionType: TransactionType.INCOME,
+                occurredAt: new Date(),
+              });
+            } catch {
+              failedIncomes.push(income.source);
             }
-          } catch {
-            // Non-fatal: budget + cards are already created; income linkage will be corrected manually.
+          }
+
+          if (failedIncomes.length > 0) {
+            toast.error(
+              `Budget created, but ${failedIncomes.length} income transaction(s) could not be created: ${failedIncomes.join(", ")}`
+            );
+          } else if (!debitCardToUse) {
+            toast.error(
+              "INCOME transactions were created without a linked debit card. You can fix the card mapping in Transactions."
+            );
           }
         }
       }

--- a/components/budgets/types.ts
+++ b/components/budgets/types.ts
@@ -1,4 +1,23 @@
-import type { StrategyType, PeriodType, CategoryType } from "@prisma/client";
+import type {
+  StrategyType,
+  PeriodType,
+  CategoryType,
+  CardType,
+} from "@prisma/client";
+
+/** Card entry for the create/duplicate budget wizard (to copy or add) */
+export interface CardToInclude {
+  id: string;
+  name: string;
+  cardType: CardType;
+  spendingLimit?: number;
+  userId: string;
+  user?: {
+    name: string | null;
+    firstName: string | null;
+    lastName: string | null;
+  } | null;
+}
 
 // Form data type
 export interface CreateBudgetFormData {

--- a/components/budgets/types.ts
+++ b/components/budgets/types.ts
@@ -26,7 +26,7 @@ export interface IncomeEntry {
   frequency: PeriodType;
 }
 
-export type StepType = "basic" | "income" | "categories" | "allocation";
+export type StepType = "basic" | "income" | "cards" | "categories" | "allocation";
 
 export interface Step {
   step: StepType;

--- a/lib/api-schemas/budgets.ts
+++ b/lib/api-schemas/budgets.ts
@@ -30,13 +30,24 @@ export const createBudgetSchema = z.object({
     allocatedAmount: z.coerce.number().min(0, "Allocated amount must be non-negative"),
   })).optional(),
   shouldCreateDefaultDebitCard: z.boolean().optional(),
-  incomes: z.array(z.object({
-    amount: z.coerce.number().positive("Income amount must be positive"),
-    source: z.string().min(1, "Income source is required"),
-    description: z.string().optional(),
-    isPlanned: z.boolean(),
-    frequency: z.enum([PeriodType.WEEKLY, PeriodType.MONTHLY, PeriodType.QUARTERLY, PeriodType.YEARLY, PeriodType.ONE_TIME]),
-  })).min(1, "At least one income is required"),
+  incomes: z
+    .array(
+      z.object({
+        amount: z.coerce.number().positive("Income amount must be positive"),
+        source: z.string().min(1, "Income source is required"),
+        description: z.string().optional(),
+        isPlanned: z.boolean(),
+        frequency: z.enum([
+          PeriodType.WEEKLY,
+          PeriodType.MONTHLY,
+          PeriodType.QUARTERLY,
+          PeriodType.YEARLY,
+          PeriodType.ONE_TIME,
+        ]),
+      }),
+    )
+    .min(1, "At least one income is required")
+    .optional(),
 })
 
 export const updateBudgetSchema = createBudgetSchema.partial()

--- a/lib/api-schemas/budgets.ts
+++ b/lib/api-schemas/budgets.ts
@@ -1,7 +1,56 @@
 import { PeriodType, StrategyType, CategoryType, CardType } from "@prisma/client"
 import { z } from "zod"
+import { calculateEndDate } from "@/lib/utils"
 
-export const createBudgetSchema = z.object({
+const parseBudgetDate = (value: string): Date | null => {
+  const datePart = value.includes("T") ? (value.split("T")[0] ?? "") : value
+  const [year, month, day] = datePart.split("-").map(Number)
+
+  if (!year || !month || !day || Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return null
+  }
+
+  return new Date(year, month - 1, day)
+}
+
+const budgetDateInvariantRefine = (
+  data: { startAt: string; endAt: string; period: PeriodType },
+  ctx: z.RefinementCtx,
+) => {
+  const startDate = parseBudgetDate(data.startAt)
+  const endDate = parseBudgetDate(data.endAt)
+
+  if (!startDate || !endDate) {
+    return
+  }
+
+  if (endDate < startDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endAt"],
+      message: "End date must be on or after start date",
+    })
+    return
+  }
+
+  if (data.period === PeriodType.ONE_TIME) {
+    return
+  }
+
+  const calculatedEndDate = calculateEndDate(startDate, data.period)
+  const diffTime = Math.abs(calculatedEndDate.getTime() - endDate.getTime())
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+
+  if (diffDays > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endAt"],
+      message: "End date should match the selected period",
+    })
+  }
+}
+
+const createBudgetBaseSchema = z.object({
   name: z.string().min(1, "Budget name is required"),
   strategy: z.enum([StrategyType.ZERO_SUM, StrategyType.FIFTY_THIRTY_TWENTY]),
   isRecurring: z.boolean(),
@@ -49,6 +98,8 @@ export const createBudgetSchema = z.object({
     .min(1, "At least one income is required")
     .optional(),
 })
+
+export const createBudgetSchema = createBudgetBaseSchema.superRefine(budgetDateInvariantRefine)
 
 const cardToIncludeSchema = z.object({
   name: z.string().min(1, "Card name is required"),
@@ -106,9 +157,9 @@ export const createBudgetWithCardsSchema = z.object({
     .min(1, "At least one income is required")
     .optional(),
   cardsToInclude: z.array(cardToIncludeSchema).optional(),
-})
+}).superRefine(budgetDateInvariantRefine)
 
-export const updateBudgetSchema = createBudgetSchema.partial()
+export const updateBudgetSchema = createBudgetBaseSchema.partial()
 
 export type CreateBudgetSchema = z.infer<typeof createBudgetSchema> 
 

--- a/lib/api-schemas/budgets.ts
+++ b/lib/api-schemas/budgets.ts
@@ -1,4 +1,4 @@
-import { PeriodType, StrategyType, CategoryType } from "@prisma/client"
+import { PeriodType, StrategyType, CategoryType, CardType } from "@prisma/client"
 import { z } from "zod"
 
 export const createBudgetSchema = z.object({
@@ -50,6 +50,66 @@ export const createBudgetSchema = z.object({
     .optional(),
 })
 
+const cardToIncludeSchema = z.object({
+  name: z.string().min(1, "Card name is required"),
+  cardType: z.nativeEnum(CardType),
+  spendingLimit: z.coerce.number().optional(),
+  userId: z.string().min(1, "User id is required"),
+})
+
+// Budget + cards + incomes in a single call. Cards are created first;
+// if any card creation/copy fails, income creation is skipped.
+export const createBudgetWithCardsSchema = z.object({
+  name: z.string().min(1, "Budget name is required"),
+  strategy: z.enum([StrategyType.ZERO_SUM, StrategyType.FIFTY_THIRTY_TWENTY]),
+  isRecurring: z.boolean(),
+  period: z.enum([PeriodType.WEEKLY, PeriodType.MONTHLY, PeriodType.QUARTERLY, PeriodType.YEARLY, PeriodType.ONE_TIME]),
+  startAt: z.string()
+    .transform((val) => {
+      // Handle date-only strings like '2025-06-20'
+      if (/^\d{4}-\d{2}-\d{2}$/.exec(val)) {
+        return `${val}T00:00:00.000Z`;
+      }
+      return val;
+    })
+    .pipe(z.string().datetime("Invalid start date format")),
+  endAt: z.string()
+    .transform((val) => {
+      // Handle date-only strings like '2025-06-20'
+      if (/^\d{4}-\d{2}-\d{2}$/.exec(val)) {
+        return `${val}T00:00:00.000Z`;
+      }
+      return val;
+    })
+    .pipe(z.string().datetime("Invalid end date format")),
+  categoryAllocations: z.array(z.object({
+    name: z.string().min(1, "Category name is required"),
+    group: z.nativeEnum(CategoryType),
+    allocatedAmount: z.coerce.number().min(0, "Allocated amount must be non-negative"),
+  })).optional(),
+  incomes: z
+    .array(
+      z.object({
+        amount: z.coerce.number().positive("Income amount must be positive"),
+        source: z.string().min(1, "Income source is required"),
+        description: z.string().optional(),
+        isPlanned: z.boolean(),
+        frequency: z.enum([
+          PeriodType.WEEKLY,
+          PeriodType.MONTHLY,
+          PeriodType.QUARTERLY,
+          PeriodType.YEARLY,
+          PeriodType.ONE_TIME,
+        ]),
+      }),
+    )
+    .min(1, "At least one income is required")
+    .optional(),
+  cardsToInclude: z.array(cardToIncludeSchema).optional(),
+})
+
 export const updateBudgetSchema = createBudgetSchema.partial()
 
 export type CreateBudgetSchema = z.infer<typeof createBudgetSchema> 
+
+export type CreateBudgetWithCardsSchema = z.infer<typeof createBudgetWithCardsSchema>

--- a/lib/api-schemas/budgets.ts
+++ b/lib/api-schemas/budgets.ts
@@ -29,6 +29,7 @@ export const createBudgetSchema = z.object({
     group: z.nativeEnum(CategoryType),
     allocatedAmount: z.coerce.number().min(0, "Allocated amount must be non-negative"),
   })).optional(),
+  shouldCreateDefaultDebitCard: z.boolean().optional(),
   incomes: z.array(z.object({
     amount: z.coerce.number().positive("Income amount must be positive"),
     source: z.string().min(1, "Income source is required"),

--- a/lib/api-services/budgets.ts
+++ b/lib/api-services/budgets.ts
@@ -13,6 +13,9 @@ export interface CreateBudgetData {
   startAt: string
   endAt: string
   isRecurring: boolean
+  // If false, we skip auto-creating the default "Main" debit card because
+  // the client will (or already does) copy/add at least one debit card.
+  shouldCreateDefaultDebitCard?: boolean
   categoryAllocations?: Array<{
     name: string
     group: CategoryType
@@ -146,48 +149,31 @@ export async function createBudget(
     },
   })
 
-  // Check if user already has any debit cards
-  // Get all users in the same account
-  const accountUsers = await tx.accountUser.findMany({
-    where: {
-      accountId: user.accountId,
-    },
-    select: {
-      userId: true,
-    },
-  });
+  const shouldCreateDefaultDebitCard = data.shouldCreateDefaultDebitCard ?? true
 
-  const userIds = accountUsers.map(au => au.userId);
+  // Used to attach "income" transactions to a card at budget-creation time.
+  // If we're skipping default debit-card creation, these transactions may be created with no cardId.
+  let mainDebitCard: Card | null = null
 
-  const existingDebitCards = await tx.card.findFirst({
-    where: {
-      userId: {
-        in: userIds,
+  if (shouldCreateDefaultDebitCard) {
+    // Check if user already has any debit cards
+    // Get all users in the same account
+    const accountUsers = await tx.accountUser.findMany({
+      where: {
+        accountId: user.accountId,
       },
-      cardType: {
-        in: [CardType.DEBIT, CardType.BUSINESS_DEBIT],
-      },
-      deleted: null,
-    },
-  });
-
-  // Create a default debit card named "Main" for the budget only if no debit cards exist
-  let mainDebitCard;
-  if (!existingDebitCards) {
-    mainDebitCard = await tx.card.create({
-      data: {
-        name: "Main",
-        cardType: CardType.DEBIT,
-        userId: user.id,
-        budgetId: budget.id,
-        amountSpent: 0,
+      select: {
+        userId: true,
       },
     });
-  } else {
-    // Find or create the main debit card for this budget
-    mainDebitCard = await tx.card.findFirst({
+
+    const userIds = accountUsers.map(au => au.userId);
+
+    const existingDebitCards = await tx.card.findFirst({
       where: {
-        budgetId: budget.id,
+        userId: {
+          in: userIds,
+        },
         cardType: {
           in: [CardType.DEBIT, CardType.BUSINESS_DEBIT],
         },
@@ -195,20 +181,44 @@ export async function createBudget(
       },
     });
 
-    // If no debit card exists for this budget, create one
-    mainDebitCard ??= await tx.card.create({
-      data: {
-        name: "Main",
-        cardType: CardType.DEBIT,
-        userId: user.id,
-        budgetId: budget.id,
-        amountSpent: 0,
-      },
-    });
+    // Create a default debit card named "Main" for the budget only if no debit cards exist
+    if (!existingDebitCards) {
+      mainDebitCard = await tx.card.create({
+        data: {
+          name: "Main",
+          cardType: CardType.DEBIT,
+          userId: user.id,
+          budgetId: budget.id,
+          amountSpent: 0,
+        },
+      });
+    } else {
+      // Find or create the main debit card for this budget
+      mainDebitCard = await tx.card.findFirst({
+        where: {
+          budgetId: budget.id,
+          cardType: {
+            in: [CardType.DEBIT, CardType.BUSINESS_DEBIT],
+          },
+          deleted: null,
+        },
+      });
+
+      // If no debit card exists for this budget, create one
+      mainDebitCard ??= await tx.card.create({
+        data: {
+          name: "Main",
+          cardType: CardType.DEBIT,
+          userId: user.id,
+          budgetId: budget.id,
+          amountSpent: 0,
+        },
+      });
+    }
   }
 
   // Create income transactions instead of income records
-  if (mainDebitCard && data.incomes && data.incomes.length > 0) {
+  if (data.incomes && data.incomes.length > 0) {
     for (const income of data.incomes) {
       await tx.transaction.create({
         data: {
@@ -216,7 +226,7 @@ export async function createBudget(
           description: income.description,
           amount: income.amount, // Positive amount for income
           budgetId: budget.id,
-          cardId: mainDebitCard.id,
+          cardId: mainDebitCard?.id,
           accountId: user.accountId,
           userId: user.id,
           transactionType: TransactionType.INCOME,

--- a/lib/api-services/budgets.ts
+++ b/lib/api-services/budgets.ts
@@ -4,7 +4,8 @@ import { formatBudget, formatBudgetCategories } from "../db/converter"
 import type { PrismaClientTx } from "../prisma"
 import type { UpdateBudgetCategoryData } from "../data-hooks/budgets/useBudgetCategories"
 import type { z } from "zod"
-import type { createBudgetSchema } from "../api-schemas/budgets"
+import type { createBudgetSchema, createBudgetWithCardsSchema } from "../api-schemas/budgets"
+import { createCard as createCardService } from "./cards"
 
 export interface CreateBudgetData {
   name: string
@@ -28,6 +29,35 @@ export interface CreateBudgetData {
     isPlanned: boolean
     frequency: PeriodType
   }>
+}
+
+export interface CardToIncludeData {
+  name: string
+  cardType: CardType
+  spendingLimit?: number
+  userId: string
+}
+
+export interface CreateBudgetWithCardsData {
+  name: string
+  strategy: StrategyType
+  period: PeriodType
+  startAt: string
+  endAt: string
+  isRecurring: boolean
+  categoryAllocations?: Array<{
+    name: string
+    group: CategoryType
+    allocatedAmount: number
+  }>
+  incomes?: Array<{
+    amount: number
+    source: string
+    description?: string
+    isPlanned: boolean
+    frequency: PeriodType
+  }>
+  cardsToInclude?: CardToIncludeData[]
 }
 
 export interface UpdateBudgetData {
@@ -237,6 +267,152 @@ export async function createBudget(
   }
 
   return budget
+}
+
+async function createBudgetWithCardsAndIncomes(
+  tx: PrismaClientTx,
+  data: z.infer<typeof createBudgetWithCardsSchema>,
+  user: User & { accountId: string }
+) {
+  const budget = await tx.budget.create({
+    data: {
+      name: data.name,
+      strategy: data.strategy,
+      period: data.period,
+      startAt: new Date(data.startAt),
+      endAt: new Date(data.endAt),
+      isRecurring: data.isRecurring,
+      accountId: user.accountId,
+    },
+  })
+
+  const failedCards: string[] = []
+  const createdCards: Card[] = []
+
+  // Create cards first (best effort). If any card fails, we skip income creation.
+  const cardsToInclude = data.cardsToInclude ?? []
+  for (const card of cardsToInclude) {
+    try {
+      const createdCard = await createCardService(tx, { ...card, budgetId: budget.id }, user)
+      createdCards.push(createdCard)
+    } catch {
+      failedCards.push(card.name)
+    }
+  }
+
+  // Ensure we have a debit card to attach incomes to.
+  const debitCards = createdCards.filter(
+    (c) => c.cardType === CardType.DEBIT || c.cardType === CardType.BUSINESS_DEBIT,
+  )
+  let debitCardToUse = debitCards.find((c) => c.name === "Main") ?? debitCards[0] ?? null
+
+  if (!debitCardToUse) {
+    try {
+      const defaultDebitCard = await createCardService(
+        tx,
+        {
+          name: "Main",
+          cardType: CardType.DEBIT,
+          userId: user.id,
+          budgetId: budget.id,
+        },
+        user,
+      )
+      createdCards.push(defaultDebitCard)
+      debitCardToUse = defaultDebitCard
+    } catch {
+      failedCards.push("Main")
+      debitCardToUse = null
+    }
+  }
+
+  // Create budget category allocations
+  if (data.categoryAllocations && data.categoryAllocations.length > 0) {
+    // Fetch all default categories to match against (same behavior as `createBudget`)
+    const defaultCategories = await tx.category.findMany({
+      where: {
+        budgetId: null,
+        defaultCategoryId: null,
+        deleted: null,
+      },
+    })
+
+    const defaultCategoryMap = new Map<string, string>()
+    defaultCategories.forEach((cat) => {
+      const key = `${cat.name}|${cat.group}`
+      defaultCategoryMap.set(key, cat.id)
+    })
+
+    for (const { name, group, allocatedAmount } of data.categoryAllocations) {
+      const key = `${name}|${group}`
+      const defaultCategoryId = defaultCategoryMap.get(key) ?? null
+
+      await tx.category.create({
+        data: {
+          budgetId: budget.id,
+          name,
+          group,
+          allocatedAmount,
+          defaultCategoryId,
+        },
+      })
+    }
+  }
+
+  const failedIncomes: string[] = []
+
+  // Requirement: if any card creation/copy fails, incomes should not be created.
+  const incomesToCreate = data.incomes ?? []
+  const debitCardId = debitCardToUse?.id
+  const shouldCreateIncomes =
+    failedCards.length === 0 && debitCardId && incomesToCreate.length > 0
+
+  if (shouldCreateIncomes) {
+    for (const income of incomesToCreate) {
+      try {
+        await tx.transaction.create({
+          data: {
+            name: income.source,
+            description: income.description,
+            amount: income.amount, // Positive amount for income
+            budgetId: budget.id,
+            cardId: debitCardId,
+            accountId: user.accountId,
+            userId: user.id,
+            transactionType: TransactionType.INCOME,
+            categoryId: null, // Income transactions don't have categories
+            occurredAt: new Date(),
+          },
+        })
+      } catch {
+        failedIncomes.push(income.source)
+      }
+    }
+  }
+
+  return {
+    message: "Budget created successfully",
+    budget,
+    failedCards,
+    failedIncomes,
+    incomesSkipped: failedCards.length > 0,
+  }
+}
+
+export async function createBudgetFromScratchWithCards(
+  tx: PrismaClientTx,
+  data: z.infer<typeof createBudgetWithCardsSchema>,
+  user: User & { accountId: string }
+) {
+  return createBudgetWithCardsAndIncomes(tx, data, user)
+}
+
+export async function duplicateBudgetWithCards(
+  tx: PrismaClientTx,
+  data: z.infer<typeof createBudgetWithCardsSchema>,
+  user: User & { accountId: string }
+) {
+  return createBudgetWithCardsAndIncomes(tx, data, user)
 }
 
 export async function updateBudget(

--- a/lib/api-services/budgets.ts
+++ b/lib/api-services/budgets.ts
@@ -156,24 +156,11 @@ export async function createBudget(
   let mainDebitCard: Card | null = null
 
   if (shouldCreateDefaultDebitCard) {
-    // Check if user already has any debit cards
-    // Get all users in the same account
-    const accountUsers = await tx.accountUser.findMany({
+    // Ensure this budget has a default debit card named "Main".
+    // (If cards were already created for this budget elsewhere, reuse them.)
+    mainDebitCard = await tx.card.findFirst({
       where: {
-        accountId: user.accountId,
-      },
-      select: {
-        userId: true,
-      },
-    });
-
-    const userIds = accountUsers.map(au => au.userId);
-
-    const existingDebitCards = await tx.card.findFirst({
-      where: {
-        userId: {
-          in: userIds,
-        },
+        budgetId: budget.id,
         cardType: {
           in: [CardType.DEBIT, CardType.BUSINESS_DEBIT],
         },
@@ -181,44 +168,21 @@ export async function createBudget(
       },
     });
 
-    // Create a default debit card named "Main" for the budget only if no debit cards exist
-    if (!existingDebitCards) {
-      mainDebitCard = await tx.card.create({
-        data: {
-          name: "Main",
-          cardType: CardType.DEBIT,
-          userId: user.id,
-          budgetId: budget.id,
-          amountSpent: 0,
-        },
-      });
-    } else {
-      // Find or create the main debit card for this budget
-      mainDebitCard = await tx.card.findFirst({
-        where: {
-          budgetId: budget.id,
-          cardType: {
-            in: [CardType.DEBIT, CardType.BUSINESS_DEBIT],
-          },
-          deleted: null,
-        },
-      });
-
-      // If no debit card exists for this budget, create one
-      mainDebitCard ??= await tx.card.create({
-        data: {
-          name: "Main",
-          cardType: CardType.DEBIT,
-          userId: user.id,
-          budgetId: budget.id,
-          amountSpent: 0,
-        },
-      });
-    }
+    mainDebitCard ??= await tx.card.create({
+      data: {
+        name: "Main",
+        cardType: CardType.DEBIT,
+        userId: user.id,
+        budgetId: budget.id,
+        amountSpent: 0,
+      },
+    });
   }
 
-  // Create income transactions instead of income records
-  if (data.incomes && data.incomes.length > 0) {
+  // Create income transactions only when we can link them to a debit card.
+  // When `shouldCreateDefaultDebitCard` is false, the client creates cards first
+  // and then creates INCOME transactions once the debit card id is available.
+  if (mainDebitCard?.id && data.incomes && data.incomes.length > 0) {
     for (const income of data.incomes) {
       await tx.transaction.create({
         data: {
@@ -226,7 +190,7 @@ export async function createBudget(
           description: income.description,
           amount: income.amount, // Positive amount for income
           budgetId: budget.id,
-          cardId: mainDebitCard?.id,
+          cardId: mainDebitCard.id,
           accountId: user.accountId,
           userId: user.id,
           transactionType: TransactionType.INCOME,

--- a/lib/data-hooks/budgets/useBudgets.ts
+++ b/lib/data-hooks/budgets/useBudgets.ts
@@ -8,6 +8,8 @@ import {
   markBudgetArchived,
   reactivateBudget,
   createBudget,
+  createBudgetFromScratchWithCards,
+  duplicateBudgetWithCards,
   duplicateBudget,
 } from "../services/budgets";
 import type { UpdateBudgetData } from "@/lib/api-services/budgets";
@@ -87,6 +89,31 @@ export const useCreateBudget = () => {
 
   return useMutation<CreateBudgetResponse, Error, CreateBudgetVariables>({
     mutationFn: createBudget,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+};
+
+type CreateBudgetWithCardsVariables = Parameters<typeof createBudgetFromScratchWithCards>[0];
+type CreateBudgetWithCardsResponse = Awaited<ReturnType<typeof createBudgetFromScratchWithCards>>;
+
+export const useCreateBudgetFromScratchWithCards = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateBudgetWithCardsResponse, Error, CreateBudgetWithCardsVariables>({
+    mutationFn: createBudgetFromScratchWithCards,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+};
+
+export const useDuplicateBudgetWithCards = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateBudgetWithCardsResponse, Error, CreateBudgetWithCardsVariables>({
+    mutationFn: duplicateBudgetWithCards,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },

--- a/lib/data-hooks/budgets/useBudgets.ts
+++ b/lib/data-hooks/budgets/useBudgets.ts
@@ -1,7 +1,16 @@
 import { keepPreviousData, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import { getBudgets, updateBudget, deleteBudget, markBudgetCompleted, markBudgetArchived, reactivateBudget } from "../services/budgets";
-import type { UpdateBudgetData, CreateBudgetData } from "@/lib/api-services/budgets";
+import {
+  getBudgets,
+  updateBudget,
+  deleteBudget,
+  markBudgetCompleted,
+  markBudgetArchived,
+  reactivateBudget,
+  createBudget,
+  duplicateBudget,
+} from "../services/budgets";
+import type { UpdateBudgetData } from "@/lib/api-services/budgets";
 import type { BudgetStatus } from "@prisma/client";
 
 export const useBudgets = (status?: BudgetStatus, excludeCardPayments?: boolean) => {
@@ -71,20 +80,7 @@ export const useCreateBudget = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateBudgetData) => {
-      return fetch("/api/budgets", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      }).then((res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to create budget: ${res.statusText}`);
-        }
-        return res.json();
-      });
-    },
+    mutationFn: createBudget,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },
@@ -119,19 +115,7 @@ export const useDuplicateBudget = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (budgetId: string) => {
-      return fetch(`/api/budgets/${budgetId}/duplicate`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).then((res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to duplicate budget: ${res.statusText}`);
-        }
-        return res.json();
-      });
-    },
+    mutationFn: duplicateBudget,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },

--- a/lib/data-hooks/budgets/useBudgets.ts
+++ b/lib/data-hooks/budgets/useBudgets.ts
@@ -13,6 +13,12 @@ import {
 import type { UpdateBudgetData } from "@/lib/api-services/budgets";
 import type { BudgetStatus } from "@prisma/client";
 
+type CreateBudgetVariables = Parameters<typeof createBudget>[0];
+type CreateBudgetResponse = Awaited<ReturnType<typeof createBudget>>;
+
+type DuplicateBudgetVariables = Parameters<typeof duplicateBudget>[0];
+type DuplicateBudgetResponse = Awaited<ReturnType<typeof duplicateBudget>>;
+
 export const useBudgets = (status?: BudgetStatus, excludeCardPayments?: boolean) => {
   const { data: session } = useSession();
 
@@ -79,7 +85,7 @@ export const useReactivateBudget = () => {
 export const useCreateBudget = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<CreateBudgetResponse, Error, CreateBudgetVariables>({
     mutationFn: createBudget,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["budgets"] });
@@ -114,7 +120,7 @@ export const useDeleteBudget = () => {
 export const useDuplicateBudget = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<DuplicateBudgetResponse, Error, DuplicateBudgetVariables>({
     mutationFn: duplicateBudget,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["budgets"] });

--- a/lib/data-hooks/services/budgets.ts
+++ b/lib/data-hooks/services/budgets.ts
@@ -1,6 +1,6 @@
 import type { BudgetWithRelations } from "@/lib/types/budget";
-import type { UpdateBudgetData } from "@/lib/api-services/budgets";
-import type { BudgetStatus } from "@prisma/client";
+import type { UpdateBudgetData, CreateBudgetData } from "@/lib/api-services/budgets";
+import type { BudgetStatus, Budget } from "@prisma/client";
 
 export const getBudgets = async (status?: BudgetStatus, excludeCardPayments?: boolean): Promise<BudgetWithRelations[]> => {
   const params = new URLSearchParams();
@@ -85,6 +85,33 @@ export const reactivateBudget = async (id: string): Promise<void> => {
   }
 };
 
+export const createBudget = async (data: CreateBudgetData): Promise<{ message: string; budget: Budget }> => {
+  const response = await fetch("/api/budgets", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
 
+  if (!response.ok) {
+    throw new Error(`Failed to create budget: ${response.statusText}`);
+  }
 
+  return (await response.json()) as { message: string; budget: Budget };
+};
 
+export const duplicateBudget = async (budgetId: string): Promise<{ message: string; budget: Budget }> => {
+  const response = await fetch(`/api/budgets/${budgetId}/duplicate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to duplicate budget: ${response.statusText}`);
+  }
+
+  return (await response.json()) as { message: string; budget: Budget };
+};

--- a/lib/data-hooks/services/budgets.ts
+++ b/lib/data-hooks/services/budgets.ts
@@ -1,5 +1,5 @@
 import type { BudgetWithRelations, SerializedBudget } from "@/lib/types/budget";
-import type { UpdateBudgetData, CreateBudgetData } from "@/lib/api-services/budgets";
+import type { UpdateBudgetData, CreateBudgetData, CreateBudgetWithCardsData } from "@/lib/api-services/budgets";
 import type { BudgetStatus } from "@prisma/client";
 
 export const getBudgets = async (status?: BudgetStatus, excludeCardPayments?: boolean): Promise<BudgetWithRelations[]> => {
@@ -102,6 +102,66 @@ export const createBudget = async (
 
   return (await response.json()) as { message: string; budget: SerializedBudget };
 };
+
+export const createBudgetFromScratchWithCards = async (
+  data: CreateBudgetWithCardsData,
+): Promise<{
+  message: string
+  budget: SerializedBudget
+  failedCards: string[]
+  failedIncomes: string[]
+  incomesSkipped: boolean
+}> => {
+  const response = await fetch("/api/budgets/create-from-scratch", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to create budget: ${response.statusText}`)
+  }
+
+  return (await response.json()) as {
+    message: string
+    budget: SerializedBudget
+    failedCards: string[]
+    failedIncomes: string[]
+    incomesSkipped: boolean
+  }
+}
+
+export const duplicateBudgetWithCards = async (
+  data: CreateBudgetWithCardsData,
+): Promise<{
+  message: string
+  budget: SerializedBudget
+  failedCards: string[]
+  failedIncomes: string[]
+  incomesSkipped: boolean
+}> => {
+  const response = await fetch("/api/budgets/duplicate", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to duplicate budget: ${response.statusText}`)
+  }
+
+  return (await response.json()) as {
+    message: string
+    budget: SerializedBudget
+    failedCards: string[]
+    failedIncomes: string[]
+    incomesSkipped: boolean
+  }
+}
 
 export const duplicateBudget = async (
   budgetId: string,

--- a/lib/data-hooks/services/budgets.ts
+++ b/lib/data-hooks/services/budgets.ts
@@ -1,6 +1,6 @@
-import type { BudgetWithRelations } from "@/lib/types/budget";
+import type { BudgetWithRelations, SerializedBudget } from "@/lib/types/budget";
 import type { UpdateBudgetData, CreateBudgetData } from "@/lib/api-services/budgets";
-import type { BudgetStatus, Budget } from "@prisma/client";
+import type { BudgetStatus } from "@prisma/client";
 
 export const getBudgets = async (status?: BudgetStatus, excludeCardPayments?: boolean): Promise<BudgetWithRelations[]> => {
   const params = new URLSearchParams();
@@ -85,7 +85,9 @@ export const reactivateBudget = async (id: string): Promise<void> => {
   }
 };
 
-export const createBudget = async (data: CreateBudgetData): Promise<{ message: string; budget: Budget }> => {
+export const createBudget = async (
+  data: CreateBudgetData,
+): Promise<{ message: string; budget: SerializedBudget }> => {
   const response = await fetch("/api/budgets", {
     method: "POST",
     headers: {
@@ -98,10 +100,12 @@ export const createBudget = async (data: CreateBudgetData): Promise<{ message: s
     throw new Error(`Failed to create budget: ${response.statusText}`);
   }
 
-  return (await response.json()) as { message: string; budget: Budget };
+  return (await response.json()) as { message: string; budget: SerializedBudget };
 };
 
-export const duplicateBudget = async (budgetId: string): Promise<{ message: string; budget: Budget }> => {
+export const duplicateBudget = async (
+  budgetId: string,
+): Promise<{ message: string; budget: SerializedBudget }> => {
   const response = await fetch(`/api/budgets/${budgetId}/duplicate`, {
     method: "POST",
     headers: {
@@ -113,5 +117,5 @@ export const duplicateBudget = async (budgetId: string): Promise<{ message: stri
     throw new Error(`Failed to duplicate budget: ${response.statusText}`);
   }
 
-  return (await response.json()) as { message: string; budget: Budget };
+  return (await response.json()) as { message: string; budget: SerializedBudget };
 };

--- a/lib/data-hooks/services/cards.ts
+++ b/lib/data-hooks/services/cards.ts
@@ -23,6 +23,7 @@ export interface CreateCardRequest {
   name: string;
   cardType: CardType;
   spendingLimit?: number;
+  userId: string;
   budgetId: string;
 }
 

--- a/lib/types/budget.ts
+++ b/lib/types/budget.ts
@@ -1,7 +1,19 @@
 import type { Budget, Category, Transaction, CategoryType, Card } from "@prisma/client";
 import type { BudgetCategoryWithCategory } from "../data-hooks/budgets/useBudgetCategories";
 
-export type BudgetWithRelations = Budget & {
+export type SerializedBudget = Omit<
+  Budget,
+  "startAt" | "endAt" | "deleted" | "createdAt" | "updatedAt"
+> & {
+  // API responses serialize Date fields to ISO strings via JSON.stringify/NextResponse.json.
+  startAt: string;
+  endAt: string;
+  deleted: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BudgetWithRelations = SerializedBudget & {
   categories: (Category & {
     transactions: Transaction[];
   })[];

--- a/src/app/api/budgets/create-from-scratch/route.ts
+++ b/src/app/api/budgets/create-from-scratch/route.ts
@@ -1,0 +1,35 @@
+import { withUser } from "@/lib/middleware/withUser"
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling"
+import prisma from "@/lib/prisma"
+import { createBudgetFromScratchWithCards } from "@/lib/api-services/budgets"
+import { createBudgetWithCardsSchema } from "@/lib/api-schemas/budgets"
+import type { User } from "@prisma/client"
+import { type NextRequest, NextResponse } from "next/server"
+import { HttpError } from "@/lib/errors"
+
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = await req.json() as unknown
+      const validatedResult = createBudgetWithCardsSchema.safeParse(body)
+
+      if (!validatedResult.success) {
+        throw new HttpError(
+          "Invalid request body",
+          400,
+          validatedResult.error,
+        )
+      }
+
+      return prisma.$transaction(async (tx) => {
+        const result = await createBudgetFromScratchWithCards(tx, validatedResult.data, user)
+        return NextResponse.json(result, { status: 201 })
+      })
+    },
+  ),
+})
+

--- a/src/app/api/budgets/create-from-scratch/route.ts
+++ b/src/app/api/budgets/create-from-scratch/route.ts
@@ -14,7 +14,13 @@ export const POST = withUser({
       _context: { params: Promise<Record<string, string>> },
       user: User & { accountId: string },
     ) => {
-      const body = await req.json() as unknown
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch {
+        throw new HttpError("Invalid request body", 400)
+      }
+
       const validatedResult = createBudgetWithCardsSchema.safeParse(body)
 
       if (!validatedResult.success) {

--- a/src/app/api/budgets/duplicate/route.ts
+++ b/src/app/api/budgets/duplicate/route.ts
@@ -14,7 +14,13 @@ export const POST = withUser({
       _context: { params: Promise<Record<string, string>> },
       user: User & { accountId: string },
     ) => {
-      const body = await req.json() as unknown
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch {
+        throw new HttpError("Invalid request body", 400)
+      }
+
       const validatedResult = createBudgetWithCardsSchema.safeParse(body)
 
       if (!validatedResult.success) {

--- a/src/app/api/budgets/duplicate/route.ts
+++ b/src/app/api/budgets/duplicate/route.ts
@@ -1,0 +1,35 @@
+import { withUser } from "@/lib/middleware/withUser"
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling"
+import prisma from "@/lib/prisma"
+import { duplicateBudgetWithCards } from "@/lib/api-services/budgets"
+import { createBudgetWithCardsSchema } from "@/lib/api-schemas/budgets"
+import type { User } from "@prisma/client"
+import { type NextRequest, NextResponse } from "next/server"
+import { HttpError } from "@/lib/errors"
+
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = await req.json() as unknown
+      const validatedResult = createBudgetWithCardsSchema.safeParse(body)
+
+      if (!validatedResult.success) {
+        throw new HttpError(
+          "Invalid request body",
+          400,
+          validatedResult.error,
+        )
+      }
+
+      return prisma.$transaction(async (tx) => {
+        const result = await duplicateBudgetWithCards(tx, validatedResult.data, user)
+        return NextResponse.json(result, { status: 201 })
+      })
+    },
+  ),
+})
+

--- a/src/app/savings/[id]/allocations/page.tsx
+++ b/src/app/savings/[id]/allocations/page.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 import { useSavingsAccount } from "@/lib/data-hooks/savings/useSavings";
 import LoadingSpinner from "@/components/LoadingSpinner";
-import { AlertCircle, PiggyBank, DollarSign, ArrowRight } from "lucide-react";
+import { AlertCircle, PiggyBank, ArrowRight } from "lucide-react";
 import { formatCurrency, formatDateUTC } from "@/lib/utils";
 import type { AllocationSummary } from "@/lib/types/savings";
 


### PR DESCRIPTION
#ISSUE
- When creating or duplicating a budget, I am unable to add cards or select cards I want and do not want to duplicate

#WHAT
- Update Modal to have a step section where user is able to add credit cards, and allow users to select and unselect credit cards to create or not create when duplicating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Cards" step in the budget wizard to add, review, and remove cards with optional spending limits and assigned users; sidebar and navigation updated.

* **Improvements**
  * Duplicating a budget pre-fills cards; submit flow reports failed card/income creation and continues where possible; submit UI reflects creation progress and disables actions while creating.
  
* **Chores**
  * Backend schemas, services, and types extended to support creating budgets with cards and an optional default-debit-card flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->