### PR TITLE
Feature 1: Account feature toggles (module on/off)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,14 +16,15 @@ Brand tokens live in `tailwind.config.ts` (single source of truth; mirrored as C
 vars in `src/styles/globals.css`). The scheme is fixed — black ink, gold, cream —
 but use the scale variants freely.
 
-| Token | Base | Use |
-|---|---|---|
-| `primary` | `#0e0e10` | Nav shell, dark surfaces, headings (`primary-800/900` for softer darks) |
+| Token       | Base      | Use                                                                               |
+| ----------- | --------- | --------------------------------------------------------------------------------- |
+| `primary`   | `#0e0e10` | Nav shell, dark surfaces, headings (`primary-800/900` for softer darks)           |
 | `secondary` | `#b9a15e` | Primary actions, active states, progress, brand accents. Scale `secondary-50…950` |
-| `accent` | `#fce5a0` | Highlights, hover washes, badges. Scale `accent-50…500` |
-| `surface` | `#f7f7f5` | Page background (`surface`), wells (`surface-muted`), cards (`white`) |
+| `accent`    | `#fce5a0` | Highlights, hover washes, badges. Scale `accent-50…500`                           |
+| `surface`   | `#f7f7f5` | Page background (`surface`), wells (`surface-muted`), cards (`white`)             |
 
 Rules:
+
 - Page background is `bg-surface` (warm off-white), never `bg-gray-50`.
 - Tint washes use alpha variants: `bg-secondary/10`, `hover:bg-secondary/15`.
 - Semantic status only: green = under budget / positive, red = over budget / destructive,
@@ -77,7 +78,7 @@ All theme values come from `components/recharts/theme.tsx`:
   (Needs/Wants/Investment): `GROUP_COLORS`. Status: `STATUS_COLORS`.
 - Axes: spread `chartAxisProps`; grid: `chartGridProps` (horizontal lines only).
 - Tooltips: `contentStyle={chartTooltipStyle}` + `labelStyle={chartTooltipLabelStyle}`
-  + `itemStyle={chartTooltipItemStyle}` — dark rounded tooltip, no default white box.
+  - `itemStyle={chartTooltipItemStyle}` — dark rounded tooltip, no default white box.
 - Empty data: render `<ChartEmptyState icon={...} message="..." />`, never a bare div.
 - Prefer **AreaChart with a soft gradient fill** over LineChart for trends; donut
   (`innerRadius`) over solid pie; rounded bar corners `radius={[6, 6, 0, 0]}`.
@@ -97,7 +98,15 @@ All theme values come from `components/recharts/theme.tsx`:
 - **Progress bars**: track `bg-gray-100 rounded-full h-2`, fill colored by status
   (gold in-progress, green complete, red over).
 - **Modals**: backdrop `bg-primary-950/40 backdrop-blur-sm`, panel `rounded-2xl
-  shadow-lifted animate-scale-in`.
+shadow-lifted animate-scale-in`.
+- **Toggle rows** (on/off preferences, e.g. Settings → Features): a row with
+  label + one-line description on the left, a pill switch on the right —
+  `role="switch"` `aria-checked`, track `h-7 w-12 rounded-full`, `bg-secondary`
+  when on / `bg-gray-200` when off, white thumb `h-5 w-5 rounded-full
+shadow-soft` translating via `translate-x-6` / `translate-x-1`. Disabled
+  rows (e.g. non-admin viewers) drop to `opacity-50 cursor-not-allowed` and
+  pair with a one-line helper explaining who can change it. Stack rows in a
+  `card-surface` with `divide-y divide-gray-200/70`.
 
 ## 8. Voice & content
 

--- a/components/FeatureDisabledState.tsx
+++ b/components/FeatureDisabledState.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { PowerOff } from "lucide-react";
+import Button from "./Button";
+
+interface FeatureDisabledStateProps {
+  /** Module name shown in the headline, e.g. "Savings". */
+  moduleLabel: string;
+}
+
+/**
+ * Shown when a user navigates directly to a module's route while it's
+ * turned off for the account (e.g. `/savings`, `/cards`). Never 404s —
+ * shared budgets may hold historical data for a module that's since been
+ * disabled, so the route must stay reachable, just not usable.
+ */
+export default function FeatureDisabledState({
+  moduleLabel,
+}: FeatureDisabledStateProps) {
+  return (
+    <div className="flex flex-1 items-center justify-center bg-surface px-4 py-16">
+      <div className="card-surface flex max-w-sm flex-col items-center gap-3 p-10 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-surface-muted text-gray-400">
+          <PowerOff className="h-7 w-7" strokeWidth={1.5} />
+        </div>
+        <h3 className="text-lg font-semibold text-gray-900">
+          {moduleLabel} is turned off
+        </h3>
+        <p className="text-sm text-gray-500">
+          This feature is turned off for your household. Your data is kept — an
+          account admin can turn it back on in settings.
+        </p>
+        <Link href="/settings?tab=features">
+          <Button variant="outline">Go to settings</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/MobileBottomNav.tsx
+++ b/components/MobileBottomNav.tsx
@@ -16,11 +16,16 @@ import {
   LogOut,
   type LucideIcon,
 } from "lucide-react";
+import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { isFeatureEnabled } from "@/lib/utils/features";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
 
 interface TabItem {
   href: string;
   icon: LucideIcon;
   label: string;
+  /** Module key gating this item; omitted for core items that are never toggleable. */
+  feature?: "savings" | "cards";
 }
 
 // Primary mobile navigation. The "More" tab opens a popup with the remaining
@@ -29,23 +34,31 @@ const tabs: TabItem[] = [
   { href: "/", icon: LayoutDashboard, label: "Overview" },
   { href: "/budgets", icon: Target, label: "Budgets" },
   { href: "/transactions", icon: Receipt, label: "Activity" },
-  { href: "/savings", icon: PiggyBank, label: "Savings" },
+  { href: "/savings", icon: PiggyBank, label: "Savings", feature: "savings" },
 ];
 
 // Destinations surfaced inside the "More" popup.
 const moreLinks: TabItem[] = [
   { href: "/categories", icon: FolderOpen, label: "Categories" },
-  { href: "/cards", icon: CreditCard, label: "Cards" },
+  { href: "/cards", icon: CreditCard, label: "Cards", feature: "cards" },
   { href: "/settings", icon: Settings, label: "Settings" },
 ];
 
 export default function MobileBottomNav() {
   const pathname = usePathname();
   const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const { data: featureSettings } = useFeatureSettings();
+  const settings = featureSettings ?? DEFAULT_FEATURE_SETTINGS;
+  const visibleTabs = tabs.filter(
+    (tab) => !tab.feature || isFeatureEnabled(settings, tab.feature),
+  );
+  const visibleMoreLinks = moreLinks.filter(
+    (link) => !link.feature || isFeatureEnabled(settings, link.feature),
+  );
 
   const isMoreActive =
     isMoreOpen ||
-    moreLinks.some(
+    visibleMoreLinks.some(
       (link) => pathname === link.href || pathname.startsWith(link.href + "/"),
     );
 
@@ -68,7 +81,7 @@ export default function MobileBottomNav() {
               bottom: "calc(56px + env(safe-area-inset-bottom) + 0.5rem)",
             }}
           >
-            {moreLinks.map((link) => {
+            {visibleMoreLinks.map((link) => {
               const isActive =
                 pathname === link.href || pathname.startsWith(link.href + "/");
               const Icon = link.icon;
@@ -107,8 +120,10 @@ export default function MobileBottomNav() {
         className="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200/70 bg-surface-card/90 backdrop-blur-md lg:hidden"
         style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
       >
-        <div className="grid grid-cols-5">
-          {tabs.map((tab) => {
+        <div
+          className={`grid ${visibleTabs.length + 1 === 5 ? "grid-cols-5" : "grid-cols-4"}`}
+        >
+          {visibleTabs.map((tab) => {
             const isActive =
               tab.href === "/"
                 ? pathname === "/"

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -19,6 +19,9 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
+import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { isFeatureEnabled } from "@/lib/utils/features";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
 
 interface SideNavProps {
   isCollapsed: boolean;
@@ -29,6 +32,8 @@ interface NavItem {
   href: string;
   icon: LucideIcon;
   label: string;
+  /** Module key gating this item; omitted for core items that are never toggleable. */
+  feature?: "savings" | "cards";
 }
 
 const navItems: NavItem[] = [
@@ -36,8 +41,8 @@ const navItems: NavItem[] = [
   { href: "/budgets", icon: Target, label: "Budgets" },
   { href: "/transactions", icon: Receipt, label: "Transactions" },
   { href: "/categories", icon: FolderOpen, label: "Categories" },
-  { href: "/cards", icon: CreditCard, label: "Cards" },
-  { href: "/savings", icon: PiggyBank, label: "Savings" },
+  { href: "/cards", icon: CreditCard, label: "Cards", feature: "cards" },
+  { href: "/savings", icon: PiggyBank, label: "Savings", feature: "savings" },
   { href: "/settings", icon: Settings, label: "Settings" },
 ];
 
@@ -45,6 +50,11 @@ export default function SideNav({ isCollapsed, setIsCollapsed }: SideNavProps) {
   const [showProfilePopup, setShowProfilePopup] = useState(false);
   const { data: session } = useSession();
   const pathname = usePathname();
+  const { data: featureSettings } = useFeatureSettings();
+  const settings = featureSettings ?? DEFAULT_FEATURE_SETTINGS;
+  const visibleNavItems = navItems.filter(
+    (item) => !item.feature || isFeatureEnabled(settings, item.feature),
+  );
 
   const handleSignOut = async () => {
     await signOut({
@@ -100,7 +110,7 @@ export default function SideNav({ isCollapsed, setIsCollapsed }: SideNavProps) {
         </div>
 
         <nav className="flex flex-col gap-1">
-          {navItems.map((item) => {
+          {visibleNavItems.map((item) => {
             const isActive =
               item.href === "/"
                 ? pathname === "/"

--- a/components/settings/FeatureToggles.tsx
+++ b/components/settings/FeatureToggles.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { toast } from "react-hot-toast";
+import { TOGGLEABLE_MODULES } from "@/lib/types/feature-settings";
+import {
+  useFeatureSettings,
+  useUpdateFeatureSettings,
+} from "@/lib/data-hooks/accounts/useFeatureSettings";
+
+interface FeatureTogglesProps {
+  /** Only ADMIN users may flip a toggle; everyone else sees them disabled. */
+  isAdmin: boolean;
+}
+
+/** A single on/off row: label + description on the left, switch on the right. */
+const ToggleRow = ({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: () => void;
+}) => (
+  <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+    <div className="min-w-0">
+      <p className="text-sm font-medium text-gray-900">{label}</p>
+      <p className="mt-0.5 text-xs text-gray-500">{description}</p>
+    </div>
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onChange}
+      className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-200 ease-out ${
+        checked ? "bg-secondary" : "bg-gray-200"
+      } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-soft transition-transform duration-200 ease-out ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  </div>
+);
+
+export default function FeatureToggles({ isAdmin }: FeatureTogglesProps) {
+  const { data: settings, isLoading } = useFeatureSettings();
+  const updateFeatureSettings = useUpdateFeatureSettings();
+
+  const handleToggle = async (
+    key: (typeof TOGGLEABLE_MODULES)[number]["key"],
+  ) => {
+    if (!settings) return;
+    const next = !settings[key];
+    try {
+      await updateFeatureSettings.mutateAsync({ [key]: next });
+      toast.success(next ? "Feature turned on" : "Feature turned off");
+    } catch (error) {
+      console.error("Failed to update feature settings:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update feature settings. Please try again.",
+      );
+    }
+  };
+
+  return (
+    <div className="card-surface p-5 sm:p-6">
+      <h3 className="text-base font-semibold tracking-tight text-gray-900">
+        Features
+      </h3>
+      <p className="mt-1 text-sm text-gray-600">
+        Turn modules on or off for your household. Turning a module off hides it
+        from navigation — your data is kept and comes back when you turn it back
+        on.
+      </p>
+
+      {!isAdmin && (
+        <p className="mt-4 rounded-xl bg-secondary-50 p-3 text-sm text-secondary-800">
+          Only account admins can change features.
+        </p>
+      )}
+
+      <div className="mt-4 divide-y divide-gray-200/70">
+        {isLoading || !settings
+          ? TOGGLEABLE_MODULES.map((module) => (
+              <div
+                key={module.key}
+                className="h-14 animate-pulse py-3 first:pt-0 last:pb-0"
+              >
+                <div className="h-full rounded-xl bg-surface-muted" />
+              </div>
+            ))
+          : TOGGLEABLE_MODULES.map((module) => (
+              <ToggleRow
+                key={module.key}
+                label={module.label}
+                description={module.description}
+                checked={settings[module.key]}
+                disabled={!isAdmin || updateFeatureSettings.isPending}
+                onChange={() => void handleToggle(module.key)}
+              />
+            ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/api-schemas/feature-settings.ts
+++ b/lib/api-schemas/feature-settings.ts
@@ -1,0 +1,13 @@
+import type { z } from "zod";
+import { featureSettingsSchema } from "@/lib/types/feature-settings";
+
+/**
+ * Body shape accepted by `PATCH /api/account/feature-settings` — any subset
+ * of the toggleable keys. The service layer merges this over the account's
+ * existing (parsed-with-fallback) settings, so omitted keys are untouched.
+ */
+export const updateFeatureSettingsSchema = featureSettingsSchema.partial();
+
+export type UpdateFeatureSettingsSchema = z.infer<
+  typeof updateFeatureSettingsSchema
+>;

--- a/lib/api-services/feature-settings.ts
+++ b/lib/api-services/feature-settings.ts
@@ -1,0 +1,56 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { HttpError } from "../errors";
+import {
+  parseFeatureSettings,
+  type FeatureSettings,
+} from "../types/feature-settings";
+import type { UpdateFeatureSettingsSchema } from "../api-schemas/feature-settings";
+
+type AccountPrisma = Pick<PrismaClient, "account">;
+
+/** Loads the account's module preferences, parsed-with-fallback. */
+export const getFeatureSettings = async (
+  prisma: AccountPrisma,
+  accountId: string,
+): Promise<FeatureSettings> => {
+  const account = await prisma.account.findUnique({
+    where: { id: accountId },
+    select: { featureSettings: true },
+  });
+
+  if (!account) {
+    throw new HttpError("Account not found", 404);
+  }
+
+  return parseFeatureSettings(account.featureSettings);
+};
+
+/**
+ * Merges `patch` over the account's existing (parsed-with-fallback) feature
+ * settings and persists the full, complete object. Returns the merged
+ * result so the route can echo it back to the caller.
+ */
+export const updateFeatureSettings = async (
+  tx: AccountPrisma,
+  accountId: string,
+  patch: UpdateFeatureSettingsSchema,
+): Promise<FeatureSettings> => {
+  const account = await tx.account.findUnique({
+    where: { id: accountId },
+    select: { featureSettings: true },
+  });
+
+  if (!account) {
+    throw new HttpError("Account not found", 404);
+  }
+
+  const current = parseFeatureSettings(account.featureSettings);
+  const merged: FeatureSettings = { ...current, ...patch };
+
+  await tx.account.update({
+    where: { id: accountId },
+    data: { featureSettings: merged as Prisma.InputJsonValue },
+  });
+
+  return merged;
+};

--- a/lib/data-hooks/accounts/useFeatureSettings.ts
+++ b/lib/data-hooks/accounts/useFeatureSettings.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import { getFeatureSettings, updateFeatureSettings } from "../services/account";
+import type { FeatureSettings } from "@/lib/types/feature-settings";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
+
+export const featureSettingsKey = ["account", "feature-settings"] as const;
+
+/**
+ * Account-wide module on/off preferences — readable by any account member.
+ * Used both by the Features settings tab and by nav/pages to hide disabled
+ * modules.
+ */
+export const useFeatureSettings = () => {
+  const { data: session } = useSession();
+
+  return useQuery({
+    queryKey: featureSettingsKey,
+    queryFn: getFeatureSettings,
+    enabled: !!session,
+    staleTime: 60 * 1000,
+  });
+};
+
+/**
+ * Convenience read of a single module's enabled state. Defaults to enabled
+ * (matches `DEFAULT_FEATURE_SETTINGS`) while the query is loading or for
+ * unauthenticated callers, so nav doesn't flash-hide items before the
+ * settings load.
+ */
+export const useIsFeatureEnabled = (
+  feature: keyof FeatureSettings,
+): boolean => {
+  const { data } = useFeatureSettings();
+  return (data ?? DEFAULT_FEATURE_SETTINGS)[feature];
+};
+
+/** ADMIN-only mutation — PATCHes a subset of module preferences. */
+export const useUpdateFeatureSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateFeatureSettings,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: featureSettingsKey });
+    },
+  });
+};

--- a/lib/data-hooks/services/account.ts
+++ b/lib/data-hooks/services/account.ts
@@ -1,0 +1,21 @@
+import type { FeatureSettings } from "@/lib/types/feature-settings";
+import { parseErrorResponse } from "./http";
+
+export const getFeatureSettings = async (): Promise<FeatureSettings> => {
+  const response = await fetch("/api/account/feature-settings");
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<FeatureSettings>;
+};
+
+export const updateFeatureSettings = async (
+  patch: Partial<FeatureSettings>,
+): Promise<FeatureSettings> => {
+  const response = await fetch("/api/account/feature-settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<FeatureSettings>;
+};

--- a/lib/types/feature-settings.ts
+++ b/lib/types/feature-settings.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+/**
+ * All toggleable/reserved module keys. `savings`, `cards`, and
+ * `aiReceiptScanning` have UI/API wired today (see `lib/utils/features.ts`
+ * and the Features tab on `/settings`). `recurringTransactions`,
+ * `notifications`, and `bankSync` are reserved for modules that don't exist
+ * yet — keeping them here now means turning them on later is a UI change,
+ * not a schema migration.
+ */
+export const FEATURE_KEYS = [
+  "savings",
+  "cards",
+  "aiReceiptScanning",
+  "recurringTransactions",
+  "notifications",
+  "bankSync",
+] as const;
+
+export type FeatureKey = (typeof FEATURE_KEYS)[number];
+
+/** Full, always-complete shape of an account's feature preferences. */
+export const featureSettingsSchema = z.object({
+  savings: z.boolean(),
+  cards: z.boolean(),
+  aiReceiptScanning: z.boolean(),
+  recurringTransactions: z.boolean(),
+  notifications: z.boolean(),
+  bankSync: z.boolean(),
+});
+
+export type FeatureSettings = z.infer<typeof featureSettingsSchema>;
+
+/** Every module starts enabled — toggles are opt-out, not opt-in. */
+export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
+  savings: true,
+  cards: true,
+  aiReceiptScanning: true,
+  recurringTransactions: true,
+  notifications: true,
+  bankSync: true,
+};
+
+/**
+ * Parses an account's stored `featureSettings` JSON into a complete
+ * `FeatureSettings` object. Merges over `DEFAULT_FEATURE_SETTINGS` key by
+ * key so:
+ * - `null` (never configured) resolves to all-defaults.
+ * - Old accounts missing newer keys (e.g. added after they last saved)
+ *   still get a default for the missing key.
+ * - Malformed/unexpected values for a single key fall back to that key's
+ *   default instead of invalidating the whole object.
+ *
+ * Never throws — always returns a complete, typed object.
+ */
+export const parseFeatureSettings = (json: unknown): FeatureSettings => {
+  const source =
+    json !== null && typeof json === "object" && !Array.isArray(json)
+      ? (json as Record<string, unknown>)
+      : {};
+
+  const result = { ...DEFAULT_FEATURE_SETTINGS };
+  for (const key of FEATURE_KEYS) {
+    const value = source[key];
+    if (typeof value === "boolean") {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+/** Metadata for a module that has a toggle rendered on the settings page. */
+export interface ToggleableModule {
+  key: FeatureKey;
+  label: string;
+  description: string;
+}
+
+/**
+ * Modules with a toggle in the Features settings UI today. Reserved keys
+ * (`recurringTransactions`, `notifications`, `bankSync`) are intentionally
+ * excluded until their features ship — showing a toggle for something that
+ * doesn't exist yet would be confusing.
+ */
+export const TOGGLEABLE_MODULES: readonly ToggleableModule[] = [
+  {
+    key: "savings",
+    label: "Savings",
+    description: "Track savings pockets and goals.",
+  },
+  {
+    key: "cards",
+    label: "Cards",
+    description: "Manage cards and card payments.",
+  },
+  {
+    key: "aiReceiptScanning",
+    label: "AI receipt scanning",
+    description: "Scan receipts to auto-fill transactions.",
+  },
+];

--- a/lib/utils/features.ts
+++ b/lib/utils/features.ts
@@ -1,0 +1,23 @@
+import type { FeatureKey, FeatureSettings } from "@/lib/types/feature-settings";
+
+// ---------------------------------------------------------------------------
+// Features vs. entitlements
+//
+// `lib/utils/entitlements.ts` answers "may they" — what the account's plan
+// permits. This file answers "do they want it" — a household preference,
+// account-wide, editable by an ADMIN via `/settings`. A module should only
+// be shown/usable when BOTH allow it: an enabled-but-unentitled feature
+// stays hidden behind the paywall, and a disabled-but-entitled feature stays
+// hidden because the household turned it off. Neither check substitutes for
+// the other.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a module is turned on for the account, per its stored preference.
+ * Pure and framework-agnostic — operates on an already-parsed
+ * `FeatureSettings` object (see `parseFeatureSettings`), never on raw JSON.
+ */
+export const isFeatureEnabled = (
+  settings: FeatureSettings,
+  feature: FeatureKey,
+): boolean => settings[feature];

--- a/prisma/migrations/20260706132459_add_account_feature_settings/migration.sql
+++ b/prisma/migrations/20260706132459_add_account_feature_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "accounts" ADD COLUMN     "featureSettings" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,11 @@ model Account {
     stripeSubscriptionId String?             @unique
     subscriptionStatus   SubscriptionStatus?
     currentPeriodEnd     DateTime?
+    // Account-wide module on/off preferences (see lib/types/feature-settings.ts).
+    // JSON so new toggleable modules don't require a migration later. Null
+    // means "never configured" — callers must merge over
+    // DEFAULT_FEATURE_SETTINGS via parseFeatureSettings, never read raw.
+    featureSettings      Json?
 
     @@index([id])
     @@index([name])

--- a/src/app/api/account/feature-settings/route.ts
+++ b/src/app/api/account/feature-settings/route.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { Role, type User } from "@prisma/client";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import { HttpError } from "@/lib/errors";
+import { updateFeatureSettingsSchema } from "@/lib/api-schemas/feature-settings";
+import {
+  getFeatureSettings,
+  updateFeatureSettings,
+} from "@/lib/api-services/feature-settings";
+
+// GET /api/account/feature-settings — any account member can read the
+// account's module on/off preferences (used to filter nav/pages and to
+// render the Features settings tab).
+export const GET = withUser({
+  GET: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const settings = await getFeatureSettings(prisma, user.accountId);
+
+      return NextResponse.json(settings, { status: 200 });
+    },
+  ),
+});
+
+// PATCH /api/account/feature-settings — ADMIN-only. Merges the given subset
+// of module preferences over the account's existing settings.
+export const PATCH = withUser({
+  PATCH: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      if (user.role !== Role.ADMIN) {
+        throw new HttpError(
+          "Only account admins can change feature settings",
+          403,
+        );
+      }
+
+      const body = (await req.json()) as unknown;
+      const validationResult = updateFeatureSettingsSchema.safeParse(body);
+
+      if (!validationResult.success) {
+        return NextResponse.json(
+          {
+            message: "Validation failed",
+            errors: validationResult.error.errors,
+          },
+          { status: 400 },
+        );
+      }
+
+      const settings = await prisma.$transaction(async (tx) =>
+        updateFeatureSettings(tx, user.accountId, validationResult.data),
+      );
+
+      return NextResponse.json(settings, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/transactions/scan-receipt/route.ts
+++ b/src/app/api/transactions/scan-receipt/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { withUser } from "@/lib/middleware/withUser";
 import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
 import prisma from "@/lib/prisma";
+import { HttpError } from "@/lib/errors";
 import { ensureBudgetOwnership } from "@/lib/utils/auth";
 import { scanReceipt } from "@/lib/api-services/receipts";
 import { scanReceiptSchema } from "@/lib/api-schemas/receipt";
@@ -11,6 +12,8 @@ import {
   paymentRequired,
 } from "@/lib/api-services/entitlements";
 import { canScanReceipt } from "@/lib/utils/entitlements";
+import { getFeatureSettings } from "@/lib/api-services/feature-settings";
+import { isFeatureEnabled } from "@/lib/utils/features";
 
 export const POST = withUser({
   POST: withUserErrorHandling(
@@ -29,6 +32,17 @@ export const POST = withUser({
             errors: validationResult.error.errors,
           },
           { status: 400 },
+        );
+      }
+
+      // Unlike the other toggles (UX-only), AI receipt scanning sends data
+      // to a third party — the opt-out must be enforced server-side, not
+      // just hidden client-side.
+      const featureSettings = await getFeatureSettings(prisma, user.accountId);
+      if (!isFeatureEnabled(featureSettings, "aiReceiptScanning")) {
+        throw new HttpError(
+          "AI receipt scanning is turned off for your account. An admin can turn it back on in settings.",
+          403,
         );
       }
 

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -6,6 +6,8 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 import PageHeader from "@/components/PageHeader";
+import FeatureDisabledState from "@/components/FeatureDisabledState";
+import { useIsFeatureEnabled } from "@/lib/data-hooks/accounts/useFeatureSettings";
 import { default as CardComponent } from "@/components/cards/Card";
 import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
 import AddCardForm from "@/components/cards/AddCardForm";
@@ -46,6 +48,7 @@ const isDuplicateCardError = (err: unknown): boolean =>
 const CardsPage = () => {
   const router = useRouter();
   const { data: session } = useSession();
+  const cardsEnabled = useIsFeatureEnabled("cards");
   const { data: apiCards, isLoading, error } = useGeneralCards();
   const deleteCardMutation = useDeleteCard();
   const createCardMutation = useCreateCard();
@@ -413,6 +416,10 @@ const CardsPage = () => {
   usePageLoading(isLoading, "Loading cards...");
   if (isLoading) {
     return null;
+  }
+
+  if (!cardsEnabled) {
+    return <FeatureDisabledState moduleLabel="Cards" />;
   }
 
   if (error) {

--- a/src/app/savings/page.tsx
+++ b/src/app/savings/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import PageHeader from "@/components/PageHeader";
+import FeatureDisabledState from "@/components/FeatureDisabledState";
+import { useIsFeatureEnabled } from "@/lib/data-hooks/accounts/useFeatureSettings";
 import { useSavings } from "@/lib/data-hooks/savings/useSavings";
 import { usePageLoading } from "@/components/ConditionalLayout";
 import StatsCard from "@/components/StatsCard";
@@ -12,6 +14,7 @@ import Button from "@/components/Button";
 import { formatCurrency, roundToCents } from "@/lib/utils";
 
 export default function SavingsPage() {
+  const savingsEnabled = useIsFeatureEnabled("savings");
   const { data: savings = [], isLoading, error } = useSavings();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
@@ -19,6 +22,7 @@ export default function SavingsPage() {
 
   usePageLoading(isLoading, "Loading savings...");
   if (isLoading) return null;
+  if (!savingsEnabled) return <FeatureDisabledState moduleLabel="Savings" />;
   if (error)
     return <div className="p-6 text-red-600">Failed to load savings</div>;
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -24,12 +24,14 @@ import {
   AlertTriangle,
   Palette,
   CreditCard,
+  ToggleLeft,
 } from "lucide-react";
 import Button from "@/components/Button";
 import { usePageLoading } from "@/components/ConditionalLayout";
 import ThemeSelector from "@/components/settings/ThemeSelector";
 import PlanComparison from "@/components/billing/PlanComparison";
 import ChangePasswordForm from "@/components/settings/ChangePasswordForm";
+import FeatureToggles from "@/components/settings/FeatureToggles";
 import { Role } from "@prisma/client";
 import { useUpdateProfile } from "@/lib/data-hooks/users/useUser";
 import {
@@ -65,9 +67,10 @@ const SettingsPageContent = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState(() =>
-    searchParams.get("tab") === "billing" ? "billing" : "profile",
-  );
+  const [activeTab, setActiveTab] = useState(() => {
+    const tab = searchParams.get("tab");
+    return tab === "billing" || tab === "features" ? tab : "profile";
+  });
   const [isEditingProfile, setIsEditingProfile] = useState(false);
   const [showCreateUserModal, setShowCreateUserModal] = useState(false);
   const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
@@ -184,6 +187,7 @@ const SettingsPageContent = () => {
   const tabs = [
     { id: "profile", label: "Profile", icon: UserIcon },
     { id: "preferences", label: "Preferences", icon: Palette },
+    { id: "features", label: "Features", icon: ToggleLeft },
     { id: "billing", label: "Billing", icon: CreditCard },
     { id: "security", label: "Security", icon: Shield },
   ];
@@ -459,6 +463,13 @@ const SettingsPageContent = () => {
                 </p>
                 <ThemeSelector />
               </div>
+            </div>
+          )}
+
+          {/* Features Tab */}
+          {activeTab === "features" && (
+            <div className="space-y-4 sm:space-y-6">
+              <FeatureToggles isAdmin={isAdmin} />
             </div>
           )}
 


### PR DESCRIPTION
## Feature 1 — Feature toggles (FREE)

Foundation for the post-subscription roadmap. Lets ADMINs turn optional modules on/off per household (**Settings → Features**). Disabling hides nav/pages **without deleting data**; re-enabling restores everything.

### What's included
- **Schema**: `Account.featureSettings Json?` (migration `add_account_feature_settings`). JSON so new modules need no migration.
- **Types**: `lib/types/feature-settings.ts` — zod schema, `DEFAULT_FEATURE_SETTINGS` (all on), `parseFeatureSettings` (per-key merge over defaults; never throws; tolerates null/missing/malformed).
- **Pure util**: `lib/utils/features.ts` — `isFeatureEnabled(settings, feature)`. Preference layer, distinct from entitlements (plan layer).
- **API**: `GET`/`PATCH /api/account/feature-settings` — GET any member, PATCH ADMIN-only (403 otherwise), zod-validated.
- **Hook**: `lib/data-hooks/accounts/useFeatureSettings.ts` (query + mutation), service in `services/account.ts`.
- **UI**: Features tab on `/settings` (toggle rows; disabled w/ helper text for non-admins). `FeatureDisabledState` shown for direct nav to a disabled `/savings` or `/cards` (no 404).
- **Nav**: `SideNav` + `MobileBottomNav` filter Savings/Cards by the flags.
- **Server-side opt-out**: `scan-receipt` route enforces `aiReceiptScanning` off (third-party data); other toggles stay UX-only per plan.
- **DESIGN.md**: documented the new toggle-row pattern.

Toggleable start set: `savings`, `cards`, `aiReceiptScanning`. Keys reserved for `recurringTransactions`, `notifications`, `bankSync` (wired as those ship). Budgets/transactions are core — never toggleable.

`pnpm check` clean; 75/75 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)