### PR TITLE
Feature 2: Recurring transactions (PREMIUM)

### DIFF
--- a/components/ConditionalLayout.tsx
+++ b/components/ConditionalLayout.tsx
@@ -16,6 +16,7 @@ import MobileBottomNav from "./MobileBottomNav";
 import LoadingSpinner from "./LoadingSpinner";
 import { MobileHeaderActionProvider } from "./MobileHeaderActionContext";
 import { useTrackNavigationHistory } from "@/lib/utils/navigation-history";
+import { useRecurringCatchUp } from "@/lib/data-hooks/recurring/useRecurringCatchUp";
 
 // Create context for main navigation state
 interface MainNavContextType {
@@ -105,6 +106,11 @@ export default function ConditionalLayout({
   // renders on every authenticated and public page) so it runs regardless
   // of section.
   useTrackNavigationHistory();
+
+  // Self-hosted/dev substitute for the recurring-transactions cron job — see
+  // lib/data-hooks/recurring/useRecurringCatchUp.ts. No-op when signed out or
+  // when nothing is due.
+  useRecurringCatchUp();
 
   // Auto-collapse main nav when entering budget pages
   useEffect(() => {

--- a/components/transactions/RecurringTransactionForm.tsx
+++ b/components/transactions/RecurringTransactionForm.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Check, Info } from "lucide-react";
+import { toast } from "react-hot-toast";
+import Modal from "../Modal";
+import Button from "../Button";
+import DateInput from "../DateInput";
+import { useActiveBudgets } from "@/lib/data-hooks/budgets/useBudgets";
+import { useBudgetCategories } from "@/lib/data-hooks/budgets/useBudgetCategories";
+import { useCards } from "@/lib/data-hooks/cards/useCards";
+import {
+  useCreateRecurringTransaction,
+  useUpdateRecurringTransaction,
+} from "@/lib/data-hooks/recurring/useRecurring";
+import type { RecurringTransactionWithRelations } from "@/lib/types/recurring";
+import { PeriodType, TransactionType } from "@prisma/client";
+import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
+import UpgradeModal from "../UpgradeModal";
+
+const FREQUENCY_LABELS: Record<PeriodType, string> = {
+  DAILY: "Daily",
+  WEEKLY: "Weekly",
+  MONTHLY: "Monthly",
+  QUARTERLY: "Quarterly",
+  YEARLY: "Yearly",
+  ONE_TIME: "One time",
+};
+
+const recurringSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  amount: z.string().refine((val) => {
+    const num = parseFloat(val);
+    return !isNaN(num) && num > 0;
+  }, "Amount is required and must be greater than 0"),
+  transactionType: z.nativeEnum(TransactionType),
+  frequency: z.nativeEnum(PeriodType),
+  nextRunAt: z.string().min(1, "Start date is required"),
+  endAt: z.string().optional(),
+  categoryId: z.string().optional(),
+  cardId: z.string().optional(),
+});
+
+type RecurringFormData = z.infer<typeof recurringSchema>;
+
+interface RecurringTransactionFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+  template?: RecurringTransactionWithRelations;
+}
+
+const toDateInputValue = (value: Date | string): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString().split("T")[0]!;
+};
+
+export default function RecurringTransactionForm({
+  isOpen,
+  onClose,
+  onSuccess,
+  template,
+}: RecurringTransactionFormProps) {
+  const isEditing = !!template;
+  const { mutate: createRecurring, isPending: isCreating } =
+    useCreateRecurringTransaction();
+  const { mutate: updateRecurring, isPending: isUpdating } =
+    useUpdateRecurringTransaction();
+  const isPending = isCreating || isUpdating;
+
+  const { data: activeBudgets = [] } = useActiveBudgets();
+  const { data: cards = [] } = useCards();
+  const [referenceBudgetId, setReferenceBudgetId] = useState("");
+  const { data: budgetCategories = [] } =
+    useBudgetCategories(referenceBudgetId);
+  const [upgradeReason, setUpgradeReason] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+    setValue,
+  } = useForm<RecurringFormData>({
+    resolver: zodResolver(recurringSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      amount: "",
+      transactionType: TransactionType.REGULAR,
+      frequency: PeriodType.MONTHLY,
+      nextRunAt: new Date().toISOString().split("T")[0],
+      endAt: "",
+      categoryId: "",
+      cardId: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (template) {
+      setValue("name", template.name ?? "");
+      setValue("description", template.description ?? "");
+      setValue("amount", Math.abs(template.amount).toString());
+      setValue("transactionType", template.transactionType);
+      setValue("frequency", template.frequency);
+      setValue("nextRunAt", toDateInputValue(template.nextRunAt));
+      setValue("endAt", template.endAt ? toDateInputValue(template.endAt) : "");
+      setValue("categoryId", template.categoryId ?? "");
+      setValue("cardId", template.cardId ?? "");
+    } else {
+      reset({
+        name: "",
+        description: "",
+        amount: "",
+        transactionType: TransactionType.REGULAR,
+        frequency: PeriodType.MONTHLY,
+        nextRunAt: new Date().toISOString().split("T")[0],
+        endAt: "",
+        categoryId: "",
+        cardId: "",
+      });
+      setReferenceBudgetId(activeBudgets[0]?.id ?? "");
+    }
+    // Only reset when the modal opens or the template being edited changes —
+    // not on every activeBudgets refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, template, setValue, reset]);
+
+  // A reference budget is only used to filter the category dropdown — the
+  // template itself doesn't store a budgetId (see lib/api-schemas/recurring.ts).
+  const currentCategoryStillListed = budgetCategories.some(
+    (bc) => bc.id === template?.categoryId,
+  );
+
+  const onSubmit = (data: RecurringFormData) => {
+    const payload = {
+      name: data.name?.trim() ? data.name.trim() : undefined,
+      description: data.description?.trim()
+        ? data.description.trim()
+        : undefined,
+      amount: Math.abs(parseFloat(data.amount)),
+      transactionType: data.transactionType,
+      frequency: data.frequency,
+      nextRunAt: new Date(data.nextRunAt).toISOString(),
+      endAt: data.endAt ? new Date(data.endAt).toISOString() : undefined,
+      categoryId: data.categoryId ?? undefined,
+      cardId: data.cardId ?? undefined,
+    };
+
+    const onError = (error: unknown) => {
+      if (error instanceof UpgradeRequiredError) {
+        setUpgradeReason(error.message);
+        return;
+      }
+      console.error("Failed to save recurring transaction:", error);
+      toast.error("Failed to save recurring transaction. Please try again.");
+    };
+
+    if (isEditing && template) {
+      updateRecurring(
+        { id: template.id, data: payload },
+        {
+          onSuccess: () => {
+            toast.success("Recurring transaction updated!");
+            onSuccess?.();
+            onClose();
+          },
+          onError,
+        },
+      );
+    } else {
+      createRecurring(payload, {
+        onSuccess: () => {
+          toast.success("Recurring transaction created!");
+          onSuccess?.();
+          onClose();
+        },
+        onError,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={
+          isEditing ? "Edit recurring transaction" : "New recurring transaction"
+        }
+        maxWidth="max-w-2xl"
+      >
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+          <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Name (optional)
+              </label>
+              <input
+                type="text"
+                {...register("name")}
+                placeholder="e.g., Rent, Netflix"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Amount <span className="text-red-500">*</span>
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-2 text-sm text-gray-500">
+                  $
+                </span>
+                <input
+                  type="number"
+                  step="0.01"
+                  {...register("amount")}
+                  placeholder="0.00"
+                  className={`w-full rounded-md border py-2 pl-8 pr-3 text-sm focus:outline-none focus:ring-1 ${
+                    errors.amount
+                      ? "border-red-300 focus:border-red-500 focus:ring-red-500"
+                      : "border-gray-300 focus:border-secondary focus:ring-secondary"
+                  }`}
+                  disabled={isPending}
+                />
+              </div>
+              {errors.amount && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.amount.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Transaction type <span className="text-red-500">*</span>
+              </label>
+              <select
+                {...register("transactionType")}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              >
+                <option value={TransactionType.REGULAR}>Regular</option>
+                <option value={TransactionType.INCOME}>Income</option>
+                <option value={TransactionType.RETURN}>Return</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Frequency <span className="text-red-500">*</span>
+              </label>
+              <select
+                {...register("frequency")}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              >
+                {Object.values(PeriodType).map((period) => (
+                  <option key={period} value={period}>
+                    {FREQUENCY_LABELS[period]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Starts on <span className="text-red-500">*</span>
+              </label>
+              <DateInput {...register("nextRunAt")} disabled={isPending} />
+              {errors.nextRunAt && (
+                <p className="mt-1 text-sm text-red-600">
+                  {errors.nextRunAt.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Ends on (optional)
+              </label>
+              <DateInput {...register("endAt")} disabled={isPending} />
+            </div>
+
+            <div>
+              <label className="mb-1 flex items-center gap-2 text-sm font-medium text-gray-700">
+                <span>Reference budget</span>
+                <div className="group relative">
+                  <Info className="h-4 w-4 text-secondary-600" />
+                  <div className="absolute bottom-full left-0 mb-2 hidden w-64 rounded-lg bg-primary-950 p-2 text-xs text-white group-hover:block">
+                    Used only to choose a category below — each occurrence posts
+                    into whichever active budget covers its date.
+                  </div>
+                </div>
+              </label>
+              <select
+                value={referenceBudgetId}
+                onChange={(e) => setReferenceBudgetId(e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              >
+                <option value="">No reference budget</option>
+                {activeBudgets.map((budget) => (
+                  <option key={budget.id} value={budget.id}>
+                    {budget.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Category (optional)
+              </label>
+              <select
+                {...register("categoryId")}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending || !referenceBudgetId}
+              >
+                <option value="">
+                  {referenceBudgetId
+                    ? "No category"
+                    : "Select a reference budget first"}
+                </option>
+                {budgetCategories.map((bc) => (
+                  <option key={bc.id} value={bc.id}>
+                    {bc.name}
+                  </option>
+                ))}
+                {isEditing &&
+                  template?.category &&
+                  !currentCategoryStillListed && (
+                    <option value={template.categoryId ?? ""}>
+                      {template.category.name} (current category)
+                    </option>
+                  )}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Payment method (optional)
+              </label>
+              <select
+                {...register("cardId")}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              >
+                <option value="">Select a payment method</option>
+                {cards.map((card) => (
+                  <option key={card.id} value={card.id}>
+                    {card.name} ({card.cardType}) - {card.user.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Description (optional)
+              </label>
+              <textarea
+                {...register("description")}
+                rows={2}
+                placeholder="Additional details"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                disabled={isPending}
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <Button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending}
+              variant="primary"
+              isLoading={isPending}
+            >
+              <Check className="mr-2 h-4 w-4" />
+              {isEditing ? "Save changes" : "Create recurring transaction"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      <UpgradeModal
+        isOpen={upgradeReason !== null}
+        onClose={() => setUpgradeReason(null)}
+        reason={upgradeReason ?? undefined}
+      />
+    </>
+  );
+}

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { X, Check, Info, Plus, Trash2 } from "lucide-react";
+import { X, Check, Info, Plus, Trash2, Repeat } from "lucide-react";
 import { toast } from "react-hot-toast";
 import {
   useCreateTransaction,
@@ -15,6 +15,9 @@ import type { BudgetCategoryWithCategory } from "@/lib/types/budget";
 import { useBudgets } from "@/lib/data-hooks/budgets/useBudgets";
 import { useCards } from "@/lib/data-hooks/cards/useCards";
 import { useBillingStatus } from "@/lib/data-hooks/billing/useBilling";
+import { useCreateRecurringTransaction } from "@/lib/data-hooks/recurring/useRecurring";
+import { runRecurringCatchUp } from "@/lib/data-hooks/services/recurring";
+import { useQueryClient } from "@tanstack/react-query";
 import type {
   CreateTransactionRequest,
   UpdateTransactionRequest,
@@ -29,7 +32,7 @@ import {
   isDebitCard as isDebitCardType,
   oldestDebitCard,
 } from "@/lib/utils/cards";
-import { CardType, TransactionType } from "@prisma/client";
+import { CardType, PeriodType, TransactionType } from "@prisma/client";
 import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
 
 // Mirrors the server-side reason string from `canSplitTransactions` in
@@ -38,6 +41,20 @@ import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
 // net on submit — see `onSubmit`).
 const SPLIT_UPGRADE_REASON =
   "Splitting a transaction across categories is a Premium feature. Upgrade to Premium to split transactions.";
+
+// Mirrors the server-side reason string from `canCreateRecurring` in
+// `lib/utils/entitlements.ts`.
+const RECURRING_UPGRADE_REASON =
+  "Recurring transactions are a Premium feature. Upgrade to Premium to automate repeating transactions.";
+
+const FREQUENCY_LABELS: Record<PeriodType, string> = {
+  DAILY: "Daily",
+  WEEKLY: "Weekly",
+  MONTHLY: "Monthly",
+  QUARTERLY: "Quarterly",
+  YEARLY: "Yearly",
+  ONE_TIME: "One time",
+};
 
 // A single row in the split editor. Kept as free-form string state (like the
 // rest of this form's amount input) rather than react-hook-form fields, since
@@ -98,6 +115,9 @@ export default function TransactionForm({
     useCreateTransaction();
   const { mutate: updateTransaction, isPending: isUpdating } =
     useUpdateTransaction();
+  const { mutate: createRecurringTransaction, isPending: isCreatingRecurring } =
+    useCreateRecurringTransaction();
+  const queryClient = useQueryClient();
   const { data: budgets = [] } = useBudgets();
   const { data: cards = [] } = useCards(undefined, budgetId);
   const { data: billingStatus } = useBillingStatus();
@@ -111,7 +131,7 @@ export default function TransactionForm({
   const [selectedBudgetId, setSelectedBudgetId] = useState<string>("");
   const { data: budgetCategories = [] } = useBudgetCategories(selectedBudgetId);
   const isEditing = !!transaction;
-  const isPending = isCreating || isUpdating;
+  const isPending = isCreating || isUpdating || isCreatingRecurring;
 
   // Split-across-categories editing state.
   const [isSplitMode, setIsSplitMode] = useState(false);
@@ -119,6 +139,25 @@ export default function TransactionForm({
   // Paywall shown when a free user tries to enable split mode, or (as a
   // safety net) if a split payload somehow reaches the server anyway.
   const [upgradeReason, setUpgradeReason] = useState<string | null>(null);
+
+  // "Make recurring" — creates a RecurringTransaction template instead of a
+  // one-off Transaction (see lib/api-services/recurring.ts). Only offered
+  // when creating (not editing) and outside split mode, since templates
+  // don't support splits.
+  const [isRecurring, setIsRecurring] = useState(false);
+  const [recurringFrequency, setRecurringFrequency] = useState<PeriodType>(
+    PeriodType.MONTHLY,
+  );
+  const [recurringEndAt, setRecurringEndAt] = useState("");
+  const canMakeRecurring = !isEditing && !isSplitMode;
+
+  const handleToggleRecurring = (checked: boolean) => {
+    if (checked && !isPremium) {
+      setUpgradeReason(RECURRING_UPGRADE_REASON);
+      return;
+    }
+    setIsRecurring(checked);
+  };
 
   // Track if we've already shown the success toast for the current mutation
   const hasShownSuccessToastRef = useRef(false);
@@ -224,6 +263,14 @@ export default function TransactionForm({
     }
   }, [canSplit, isSplitMode]);
 
+  // "Make recurring" is only offered while creating (not editing) and
+  // outside split mode — turn it off if either becomes true mid-edit.
+  useEffect(() => {
+    if (!canMakeRecurring && isRecurring) {
+      setIsRecurring(false);
+    }
+  }, [canMakeRecurring, isRecurring]);
+
   const handleToggleSplitMode = (checked: boolean) => {
     if (checked && !isPremium) {
       setUpgradeReason(SPLIT_UPGRADE_REASON);
@@ -309,6 +356,72 @@ export default function TransactionForm({
   ]);
 
   const onSubmit = (data: TransactionFormData) => {
+    // "Make recurring" creates a RecurringTransaction template instead of a
+    // one-off Transaction — the budget doesn't apply (occurrences resolve
+    // their own budget by date at post time), but everything else about the
+    // entered transaction carries over as the template.
+    if (canMakeRecurring && isRecurring) {
+      createRecurringTransaction(
+        {
+          name: data.name ?? undefined,
+          description: data.description ?? undefined,
+          amount: Math.abs(parseFloat(data.amount)),
+          categoryId:
+            data.categoryId && data.categoryId.trim() !== ""
+              ? data.categoryId
+              : undefined,
+          cardId: data.cardId ?? undefined,
+          transactionType: data.transactionType,
+          frequency: recurringFrequency,
+          nextRunAt: (data.occurredAt
+            ? new Date(data.occurredAt)
+            : new Date()
+          ).toISOString(),
+          endAt: recurringEndAt
+            ? new Date(recurringEndAt).toISOString()
+            : undefined,
+        },
+        {
+          onSuccess: () => {
+            toast.success("Recurring transaction created!");
+            // Post the first occurrence right away if it's already due
+            // (e.g. start date is today or in the past) — otherwise the
+            // user would have to wait for the next cron/catch-up run to see
+            // anything in their transaction list.
+            runRecurringCatchUp()
+              .then((result) => {
+                if (result.posted > 0) {
+                  void queryClient.invalidateQueries({
+                    queryKey: ["transactions"],
+                  });
+                  void queryClient.invalidateQueries({
+                    queryKey: ["allTransactions"],
+                  });
+                  void queryClient.invalidateQueries({ queryKey: ["budget"] });
+                  void queryClient.invalidateQueries({ queryKey: ["budgets"] });
+                }
+              })
+              .catch((error: unknown) => {
+                console.error("Recurring catch-up failed:", error);
+              });
+            onSuccess?.();
+            onClose();
+          },
+          onError: (error: unknown) => {
+            if (error instanceof UpgradeRequiredError) {
+              setUpgradeReason(error.message);
+              return;
+            }
+            console.error("Failed to create recurring transaction:", error);
+            toast.error(
+              "Failed to create recurring transaction. Please try again.",
+            );
+          },
+        },
+      );
+      return;
+    }
+
     // When split mode is on and valid, build the splits payload and omit
     // categoryId entirely (the server clears/ignores it when splits are
     // present — see lib/api-schemas/transactions.ts).
@@ -878,6 +991,82 @@ export default function TransactionForm({
           </div>
         </div>
 
+        {/* Make recurring — creates a RecurringTransaction template instead
+            of a one-off transaction. Only offered when creating (not
+            editing) and outside split mode (see canMakeRecurring). */}
+        {canMakeRecurring && (
+          <div className="rounded-xl border border-gray-200 bg-surface p-3">
+            <div className="flex items-center justify-between gap-2">
+              <label className="flex min-h-[44px] flex-1 cursor-pointer items-center gap-2 text-sm font-medium text-gray-700">
+                <Repeat className="h-4 w-4 text-gray-500" />
+                <span>Make this a recurring transaction</span>
+              </label>
+              {isPremium ? (
+                <span className="relative inline-flex h-6 w-11 flex-shrink-0 items-center">
+                  <input
+                    type="checkbox"
+                    checked={isRecurring}
+                    onChange={(e) => handleToggleRecurring(e.target.checked)}
+                    disabled={isPending}
+                    aria-label="Make this a recurring transaction"
+                    className="peer sr-only"
+                  />
+                  <span className="absolute inset-0 rounded-full bg-gray-200 transition-colors duration-200 peer-checked:bg-secondary" />
+                  <span className="absolute left-0.5 h-5 w-5 rounded-full bg-white shadow-soft transition-transform duration-200 peer-checked:translate-x-5" />
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setUpgradeReason(RECURRING_UPGRADE_REASON)}
+                  aria-label="Upgrade to Premium to create recurring transactions"
+                  className="inline-flex items-center rounded-full bg-secondary-100 px-2.5 py-0.5 text-xs font-medium text-secondary-700 transition-colors hover:bg-secondary-200"
+                >
+                  Premium
+                </button>
+              )}
+            </div>
+
+            {isRecurring && (
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-500">
+                    Frequency
+                  </label>
+                  <select
+                    value={recurringFrequency}
+                    onChange={(e) =>
+                      setRecurringFrequency(e.target.value as PeriodType)
+                    }
+                    disabled={isPending}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+                  >
+                    {Object.values(PeriodType).map((period) => (
+                      <option key={period} value={period}>
+                        {FREQUENCY_LABELS[period]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-500">
+                    Ends on (optional)
+                  </label>
+                  <DateInput
+                    value={recurringEndAt}
+                    onChange={(e) => setRecurringEndAt(e.target.value)}
+                    disabled={isPending}
+                  />
+                </div>
+                <p className="text-xs text-gray-500 sm:col-span-2">
+                  The first occurrence posts using the &quot;Occurred At&quot;
+                  date above (or today, if left blank). Future occurrences post
+                  automatically into whichever budget covers their date.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Action Buttons */}
         <div className="flex justify-end space-x-3 border-t border-gray-200 pt-4">
           <Button onClick={onClose} disabled={isPending} variant="outline">
@@ -890,7 +1079,11 @@ export default function TransactionForm({
             isLoading={isPending}
           >
             <Check className="mr-2 h-4 w-4" />
-            {isEditing ? "Update Transaction" : "Add Transaction"}
+            {isRecurring && canMakeRecurring
+              ? "Create recurring transaction"
+              : isEditing
+                ? "Update Transaction"
+                : "Add Transaction"}
           </Button>
         </div>
       </form>

--- a/components/transactions/TransactionsPageNavigation.tsx
+++ b/components/transactions/TransactionsPageNavigation.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Receipt, Repeat } from "lucide-react";
+import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { isFeatureEnabled } from "@/lib/utils/features";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
+
+interface TransactionsNavItem {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+}
+
+/**
+ * Sub-nav shown on `/transactions` and `/transactions/recurring`, mirroring
+ * the pill-row pattern used for savings/budget sub-pages
+ * (`SavingsPageNavigation`/`BudgetPageNavigation`). The Recurring tab is
+ * hidden entirely when the household has turned the module off (see
+ * `FeatureDisabledState`, which the recurring page itself falls back to if
+ * someone still lands there via a direct link).
+ */
+export default function TransactionsPageNavigation() {
+  const pathname = usePathname();
+  const { data: featureSettings } = useFeatureSettings();
+  const settings = featureSettings ?? DEFAULT_FEATURE_SETTINGS;
+  const recurringEnabled = isFeatureEnabled(settings, "recurringTransactions");
+
+  const navItems: TransactionsNavItem[] = [
+    {
+      href: "/transactions",
+      icon: <Receipt className="h-4 w-4" />,
+      label: "Transactions",
+    },
+    ...(recurringEnabled
+      ? [
+          {
+            href: "/transactions/recurring",
+            icon: <Repeat className="h-4 w-4" />,
+            label: "Recurring",
+          },
+        ]
+      : []),
+  ];
+
+  if (navItems.length < 2) return null;
+
+  return (
+    <>
+      {/* Desktop: in-flow pill row under the page header */}
+      <div className="hidden bg-surface px-4 pt-3 sm:px-6 lg:block lg:px-8">
+        <nav className="inline-flex rounded-full bg-surface-muted p-1">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex shrink-0 items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-all duration-200 ease-out ${
+                  isActive
+                    ? "bg-surface-card text-gray-900 shadow-soft"
+                    : "text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+
+      {/* Mobile: floating pill bar docked just above the bottom tab bar */}
+      <div
+        className="fixed inset-x-0 z-50 flex justify-center px-3 lg:hidden"
+        style={{ bottom: "calc(56px + env(safe-area-inset-bottom) + 0.5rem)" }}
+      >
+        <nav className="scrollbar-hide flex max-w-full gap-1 overflow-x-auto rounded-full border border-gray-400/60 bg-surface-muted/95 p-1 shadow-lifted backdrop-blur-md">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex shrink-0 items-center gap-1.5 rounded-full px-3.5 py-2 text-xs font-medium transition-all duration-200 ease-out ${
+                  isActive
+                    ? "bg-secondary/15 text-gray-900"
+                    : "text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </>
+  );
+}

--- a/lib/api-schemas/recurring.ts
+++ b/lib/api-schemas/recurring.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { PeriodType, TransactionType } from "@prisma/client";
+
+// A recurring template mirrors the fields on `createTransactionSchema`
+// (see lib/api-schemas/transactions.ts) minus `budgetId` — recurring
+// occurrences resolve their budget at post time from the occurrence date
+// (see lib/utils/recurring.ts#findBudgetForOccurrence), not at creation time.
+export const createRecurringTransactionSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  amount: z.number(),
+  categoryId: z.string().optional(),
+  cardId: z.string().optional(),
+  transactionType: z
+    .nativeEnum(TransactionType)
+    .optional()
+    .default(TransactionType.REGULAR),
+  frequency: z.nativeEnum(PeriodType),
+  // The first occurrence date. If it's due (<= now) once created, the lazy
+  // catch-up / cron posts it on the next run.
+  nextRunAt: z.string().min(1, "Start date is required"),
+  endAt: z.string().optional(),
+});
+
+export const updateRecurringTransactionSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  amount: z.number().optional(),
+  categoryId: z.string().optional(),
+  cardId: z.string().optional(),
+  transactionType: z.nativeEnum(TransactionType).optional(),
+  frequency: z.nativeEnum(PeriodType).optional(),
+  nextRunAt: z.string().optional(),
+  endAt: z.string().nullable().optional(),
+  paused: z.boolean().optional(),
+});
+
+export type CreateRecurringTransactionSchema = z.infer<
+  typeof createRecurringTransactionSchema
+>;
+export type UpdateRecurringTransactionSchema = z.infer<
+  typeof updateRecurringTransactionSchema
+>;

--- a/lib/api-services/entitlements.ts
+++ b/lib/api-services/entitlements.ts
@@ -53,6 +53,14 @@ export const BUDGET_LOCKED_REASON =
   "This budget is locked because your account is over the Free plan limit. Upgrade to Premium to edit it.";
 
 /**
+ * Shared paywall copy for a write blocked because recurring transactions are
+ * view-only on the Free plan (e.g. templates kept read-only after a
+ * downgrade). Pass to `paymentRequired` from the route handler.
+ */
+export const RECURRING_LOCKED_REASON =
+  "Recurring transactions are read-only on the Free plan. Upgrade to Premium to manage them.";
+
+/**
  * Shared paywall copy for a write blocked because the savings pocket is locked
  * after a downgrade. Pass to `paymentRequired` from the route handler.
  */

--- a/lib/api-services/recurring.ts
+++ b/lib/api-services/recurring.ts
@@ -1,0 +1,280 @@
+import { type User, type RecurringTransaction } from "@prisma/client";
+import type {
+  CreateRecurringTransactionSchema,
+  UpdateRecurringTransactionSchema,
+} from "@/lib/api-schemas/recurring";
+import type { PrismaClientTx } from "../prisma";
+import { HttpError } from "../errors";
+import { getAccountEntitlements } from "./entitlements";
+import { isPremium } from "../utils/entitlements";
+import {
+  computeDueOccurrences,
+  findBudgetForOccurrence,
+  previewUpcomingOccurrences,
+  type BudgetWindow,
+} from "../utils/recurring";
+
+const recurringInclude = {
+  category: {
+    include: {
+      defaultCategory: true,
+    },
+  },
+  card: true,
+} as const;
+
+export const getRecurringTransactions = async (
+  tx: PrismaClientTx,
+  accountId: string,
+) => {
+  const templates = await tx.recurringTransaction.findMany({
+    where: { accountId, deleted: null },
+    include: recurringInclude,
+    orderBy: { createdAt: "desc" },
+  });
+
+  const activeBudgets: BudgetWindow[] = await tx.budget.findMany({
+    where: { accountId, deleted: null, status: "ACTIVE" },
+    select: { id: true, status: true, startAt: true, endAt: true },
+  });
+
+  const now = new Date();
+
+  return templates.map((template) => ({
+    ...template,
+    upcomingOccurrences: previewUpcomingOccurrences(template, 3),
+    // Overdue and no ACTIVE budget currently covers the next occurrence —
+    // surfaced in the UI as "needs a budget" rather than silently stalling.
+    needsBudget:
+      !template.paused &&
+      template.nextRunAt.getTime() <= now.getTime() &&
+      findBudgetForOccurrence(template.nextRunAt, activeBudgets) === null,
+  }));
+};
+
+const getOwnedRecurringTransaction = async (
+  tx: PrismaClientTx,
+  id: string,
+  user: User & { accountId: string },
+): Promise<RecurringTransaction> => {
+  const template = await tx.recurringTransaction.findFirst({
+    where: { id, accountId: user.accountId, deleted: null },
+  });
+  if (!template) {
+    throw new HttpError("Recurring transaction not found", 404);
+  }
+  return template;
+};
+
+export const createRecurringTransaction = async (
+  tx: PrismaClientTx,
+  data: CreateRecurringTransactionSchema,
+  user: User & { accountId: string },
+) => {
+  return tx.recurringTransaction.create({
+    data: {
+      name: data.name,
+      description: data.description,
+      amount: data.amount,
+      categoryId:
+        data.categoryId && data.categoryId.trim() !== ""
+          ? data.categoryId
+          : null,
+      cardId: data.cardId && data.cardId.trim() !== "" ? data.cardId : null,
+      transactionType: data.transactionType,
+      frequency: data.frequency,
+      nextRunAt: new Date(data.nextRunAt),
+      endAt: data.endAt ? new Date(data.endAt) : null,
+      accountId: user.accountId,
+      userId: user.id,
+    },
+    include: recurringInclude,
+  });
+};
+
+export const updateRecurringTransaction = async (
+  tx: PrismaClientTx,
+  id: string,
+  data: UpdateRecurringTransactionSchema,
+  user: User & { accountId: string },
+) => {
+  await getOwnedRecurringTransaction(tx, id, user);
+
+  return tx.recurringTransaction.update({
+    where: { id },
+    data: {
+      name: data.name,
+      description: data.description,
+      amount: data.amount,
+      categoryId:
+        data.categoryId !== undefined
+          ? data.categoryId.trim() !== ""
+            ? data.categoryId
+            : null
+          : undefined,
+      cardId:
+        data.cardId !== undefined
+          ? data.cardId.trim() !== ""
+            ? data.cardId
+            : null
+          : undefined,
+      transactionType: data.transactionType,
+      frequency: data.frequency,
+      nextRunAt: data.nextRunAt ? new Date(data.nextRunAt) : undefined,
+      endAt:
+        data.endAt !== undefined
+          ? data.endAt
+            ? new Date(data.endAt)
+            : null
+          : undefined,
+      paused: data.paused,
+    },
+    include: recurringInclude,
+  });
+};
+
+export const deleteRecurringTransaction = async (
+  tx: PrismaClientTx,
+  id: string,
+  user: User & { accountId: string },
+) => {
+  await getOwnedRecurringTransaction(tx, id, user);
+
+  return tx.recurringTransaction.update({
+    where: { id },
+    data: { deleted: new Date() },
+  });
+};
+
+/**
+ * Posts every due occurrence for a single template, advancing `nextRunAt` as
+ * it goes so a crash or concurrent run mid-loop can't double-post — each
+ * successful post persists the pointer past that occurrence before moving to
+ * the next one. Stops (without erroring) at the first occurrence with no
+ * covering ACTIVE budget, leaving `nextRunAt` parked there — the "needs a
+ * budget" hold — so the very next run retries it once a budget exists.
+ *
+ * Safe to call twice for the same template/now: the pointer guard means a
+ * repeat call finds nothing new to post (see `computeDueOccurrences`), and
+ * the `(recurringTransactionId, occurredAt)` unique index is a backstop in
+ * case two runs somehow race before either persists its pointer update.
+ */
+export const postDueOccurrencesForTemplate = async (
+  tx: PrismaClientTx,
+  template: RecurringTransaction,
+  now: Date,
+): Promise<{ posted: number; heldAt: Date | null }> => {
+  if (template.paused || template.deleted) {
+    return { posted: 0, heldAt: null };
+  }
+
+  const { occurrences, nextRunAt: finalPointer } = computeDueOccurrences(
+    template,
+    now,
+  );
+  if (occurrences.length === 0) {
+    return { posted: 0, heldAt: null };
+  }
+
+  const activeBudgets: BudgetWindow[] = await tx.budget.findMany({
+    where: { accountId: template.accountId, deleted: null, status: "ACTIVE" },
+    select: { id: true, status: true, startAt: true, endAt: true },
+  });
+
+  let posted = 0;
+
+  for (let i = 0; i < occurrences.length; i++) {
+    const occurrenceDate = occurrences[i]!;
+    const budget = findBudgetForOccurrence(occurrenceDate, activeBudgets);
+
+    if (!budget) {
+      // Hold: no budget covers this occurrence yet. Park the pointer here —
+      // don't touch later (also-due) occurrences until this one clears.
+      await tx.recurringTransaction.update({
+        where: { id: template.id },
+        data: { nextRunAt: occurrenceDate },
+      });
+      return { posted, heldAt: occurrenceDate };
+    }
+
+    // Idempotency backstop: skip if this exact occurrence was already
+    // posted (the unique index would reject a duplicate create anyway).
+    const alreadyPosted = await tx.transaction.findFirst({
+      where: {
+        recurringTransactionId: template.id,
+        occurredAt: occurrenceDate,
+      },
+      select: { id: true },
+    });
+
+    if (!alreadyPosted) {
+      await tx.transaction.create({
+        data: {
+          name: template.name,
+          description: template.description,
+          amount: template.amount,
+          budgetId: budget.id,
+          categoryId: template.categoryId,
+          cardId: template.cardId,
+          accountId: template.accountId,
+          userId: template.userId,
+          transactionType: template.transactionType,
+          occurredAt: occurrenceDate,
+          recurringTransactionId: template.id,
+        },
+      });
+    }
+    posted++;
+
+    const isLast = i === occurrences.length - 1;
+    const nextPointer = isLast ? finalPointer : occurrences[i + 1]!;
+
+    await tx.recurringTransaction.update({
+      where: { id: template.id },
+      data:
+        nextPointer === null
+          ? { nextRunAt: occurrenceDate, paused: true } // schedule exhausted
+          : { nextRunAt: nextPointer },
+    });
+  }
+
+  return { posted, heldAt: null };
+};
+
+export interface RecurringPostingSummary {
+  templateId: string;
+  posted: number;
+  heldAt: Date | null;
+}
+
+/**
+ * Posts every due, unpaused template for a single account. Premium-gated —
+ * recurring transactions are a Premium feature end to end, so a downgraded
+ * account's existing templates stop auto-posting (they stay visible,
+ * view-only, per `canCreateRecurring`) until the account is premium again.
+ * Used by both the lazy on-login catch-up and the cron job (looping accounts).
+ */
+export const postDueRecurringTransactionsForAccount = async (
+  tx: PrismaClientTx,
+  accountId: string,
+  now: Date = new Date(),
+): Promise<RecurringPostingSummary[]> => {
+  const account = await getAccountEntitlements(tx, accountId);
+  if (!isPremium(account)) return [];
+
+  const templates = await tx.recurringTransaction.findMany({
+    where: {
+      accountId,
+      deleted: null,
+      paused: false,
+      nextRunAt: { lte: now },
+    },
+  });
+
+  const summaries: RecurringPostingSummary[] = [];
+  for (const template of templates) {
+    const result = await postDueOccurrencesForTemplate(tx, template, now);
+    summaries.push({ templateId: template.id, ...result });
+  }
+  return summaries;
+};

--- a/lib/data-hooks/recurring/useRecurring.ts
+++ b/lib/data-hooks/recurring/useRecurring.ts
@@ -1,0 +1,91 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import {
+  createRecurringTransaction,
+  deleteRecurringTransaction,
+  getRecurringTransactions,
+  updateRecurringTransaction,
+} from "../services/recurring";
+import type {
+  CreateRecurringTransactionRequest,
+  UpdateRecurringTransactionRequest,
+} from "@/lib/types/recurring";
+
+export const recurringTransactionsKey = ["recurring"] as const;
+
+/** Recurring templates for the account — readable by any member (free
+ * accounts see their existing templates read-only; see the management page). */
+export const useRecurringTransactions = () => {
+  const { data: session } = useSession();
+
+  return useQuery({
+    queryKey: recurringTransactionsKey,
+    queryFn: getRecurringTransactions,
+    enabled: !!session,
+    staleTime: 60 * 1000,
+  });
+};
+
+// A recurring template can post a transaction into any budget/card, and
+// posting also touches the transactions list — invalidate broadly rather
+// than trying to track which budgets/cards were affected.
+const invalidateRecurringAndTransactions = (
+  queryClient: ReturnType<typeof useQueryClient>,
+) => {
+  void queryClient.invalidateQueries({ queryKey: recurringTransactionsKey });
+  void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+  void queryClient.invalidateQueries({ queryKey: ["allTransactions"] });
+  void queryClient.invalidateQueries({ queryKey: ["budget"] });
+  void queryClient.invalidateQueries({ queryKey: ["budgets"] });
+};
+
+export const useCreateRecurringTransaction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateRecurringTransactionRequest) =>
+      createRecurringTransaction(data),
+    onSuccess: () => invalidateRecurringAndTransactions(queryClient),
+  });
+};
+
+export const useUpdateRecurringTransaction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateRecurringTransactionRequest;
+    }) => updateRecurringTransaction(id, data),
+    onSuccess: () => invalidateRecurringAndTransactions(queryClient),
+  });
+};
+
+type UpdateMutation = ReturnType<typeof useUpdateRecurringTransaction>;
+
+/** Convenience wrapper over the update mutation for the pause/resume toggle. */
+export const useToggleRecurringTransactionPaused = () => {
+  const mutation = useUpdateRecurringTransaction();
+  return {
+    ...mutation,
+    mutate: (
+      args: { id: string; paused: boolean },
+      options?: Parameters<UpdateMutation["mutate"]>[1],
+    ) =>
+      mutation.mutate({ id: args.id, data: { paused: args.paused } }, options),
+    mutateAsync: (args: { id: string; paused: boolean }) =>
+      mutation.mutateAsync({ id: args.id, data: { paused: args.paused } }),
+  };
+};
+
+export const useDeleteRecurringTransaction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteRecurringTransaction(id),
+    onSuccess: () => invalidateRecurringAndTransactions(queryClient),
+  });
+};

--- a/lib/data-hooks/recurring/useRecurringCatchUp.ts
+++ b/lib/data-hooks/recurring/useRecurringCatchUp.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { runRecurringCatchUp } from "../services/recurring";
+import { recurringTransactionsKey } from "./useRecurring";
+
+/**
+ * Fires the idempotent recurring-transactions catch-up (`POST
+ * /api/recurring/catch-up`) once per authenticated session. This is the
+ * self-hosted/dev substitute for the Vercel cron job (`/api/cron/recurring`)
+ * — without it, recurring transactions would only ever post when that cron
+ * route is configured and actually running. Mounted once in
+ * `ConditionalLayout` so it covers every page a signed-in user lands on.
+ *
+ * Cheap: no-ops server-side when nothing is due. Idempotent: safe to fire
+ * more than once (e.g. a remount) since the guard is `hasRunRef`, and the
+ * server-side posting itself is idempotent regardless.
+ */
+export const useRecurringCatchUp = () => {
+  const { data: session } = useSession();
+  const queryClient = useQueryClient();
+  const hasRunRef = useRef(false);
+
+  useEffect(() => {
+    if (!session || hasRunRef.current) return;
+    hasRunRef.current = true;
+
+    runRecurringCatchUp()
+      .then((result) => {
+        if (result.posted > 0) {
+          void queryClient.invalidateQueries({
+            queryKey: recurringTransactionsKey,
+          });
+          void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+          void queryClient.invalidateQueries({ queryKey: ["allTransactions"] });
+          void queryClient.invalidateQueries({ queryKey: ["budget"] });
+          void queryClient.invalidateQueries({ queryKey: ["budgets"] });
+        }
+      })
+      .catch((error: unknown) => {
+        // Never surface this to the user — it's a background best-effort
+        // sync, not something they initiated.
+        console.error("Recurring catch-up failed:", error);
+      });
+  }, [session, queryClient]);
+};

--- a/lib/data-hooks/services/recurring.ts
+++ b/lib/data-hooks/services/recurring.ts
@@ -1,0 +1,50 @@
+import type {
+  CreateRecurringTransactionRequest,
+  RecurringTransactionWithRelations,
+  UpdateRecurringTransactionRequest,
+} from "@/lib/types/recurring";
+import { parseErrorResponse } from "./http";
+
+export const getRecurringTransactions = async (): Promise<
+  RecurringTransactionWithRelations[]
+> => {
+  const response = await fetch("/api/recurring");
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<RecurringTransactionWithRelations[]>;
+};
+
+export const createRecurringTransaction = async (
+  data: CreateRecurringTransactionRequest,
+): Promise<RecurringTransactionWithRelations> => {
+  const response = await fetch("/api/recurring", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<RecurringTransactionWithRelations>;
+};
+
+export const updateRecurringTransaction = async (
+  id: string,
+  data: UpdateRecurringTransactionRequest,
+): Promise<RecurringTransactionWithRelations> => {
+  const response = await fetch(`/api/recurring/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<RecurringTransactionWithRelations>;
+};
+
+export const deleteRecurringTransaction = async (id: string): Promise<void> => {
+  const response = await fetch(`/api/recurring/${id}`, { method: "DELETE" });
+  if (!response.ok) return parseErrorResponse(response);
+};
+
+export const runRecurringCatchUp = async (): Promise<{ posted: number }> => {
+  const response = await fetch("/api/recurring/catch-up", { method: "POST" });
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<{ posted: number }>;
+};

--- a/lib/types/feature-settings.ts
+++ b/lib/types/feature-settings.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
 /**
- * All toggleable/reserved module keys. `savings`, `cards`, and
- * `aiReceiptScanning` have UI/API wired today (see `lib/utils/features.ts`
- * and the Features tab on `/settings`). `recurringTransactions`,
- * `notifications`, and `bankSync` are reserved for modules that don't exist
+ * All toggleable/reserved module keys. `savings`, `cards`,
+ * `aiReceiptScanning`, and `recurringTransactions` have UI/API wired today
+ * (see `lib/utils/features.ts` and the Features tab on `/settings`).
+ * `notifications` and `bankSync` are reserved for modules that don't exist
  * yet — keeping them here now means turning them on later is a UI change,
  * not a schema migration.
  */
@@ -78,9 +78,9 @@ export interface ToggleableModule {
 
 /**
  * Modules with a toggle in the Features settings UI today. Reserved keys
- * (`recurringTransactions`, `notifications`, `bankSync`) are intentionally
- * excluded until their features ship — showing a toggle for something that
- * doesn't exist yet would be confusing.
+ * (`notifications`, `bankSync`) are intentionally excluded until their
+ * features ship — showing a toggle for something that doesn't exist yet
+ * would be confusing.
  */
 export const TOGGLEABLE_MODULES: readonly ToggleableModule[] = [
   {
@@ -97,5 +97,10 @@ export const TOGGLEABLE_MODULES: readonly ToggleableModule[] = [
     key: "aiReceiptScanning",
     label: "AI receipt scanning",
     description: "Scan receipts to auto-fill transactions.",
+  },
+  {
+    key: "recurringTransactions",
+    label: "Recurring transactions",
+    description: "Auto-post repeating transactions like rent and bills.",
   },
 ];

--- a/lib/types/recurring.ts
+++ b/lib/types/recurring.ts
@@ -1,0 +1,28 @@
+import type { Card, Category, RecurringTransaction } from "@prisma/client";
+import type {
+  CreateRecurringTransactionSchema,
+  UpdateRecurringTransactionSchema,
+} from "@/lib/api-schemas/recurring";
+
+export type CreateRecurringTransactionRequest =
+  CreateRecurringTransactionSchema;
+export type UpdateRecurringTransactionRequest =
+  UpdateRecurringTransactionSchema;
+
+/** A recurring template as returned by GET /api/recurring, with its relations
+ * and the computed preview fields the management UI renders. */
+export type RecurringTransactionWithRelations = RecurringTransaction & {
+  category:
+    | (Category & {
+        defaultCategoryId: string | null;
+        defaultCategory?: Category | null;
+      })
+    | null;
+  card: Card | null;
+  /** Next up-to-3 occurrence dates from the current `nextRunAt`, for the
+   * "upcoming" preview — doesn't mutate anything. */
+  upcomingOccurrences: string[] | Date[];
+  /** True when the template is overdue and no ACTIVE budget currently covers
+   * its next occurrence date — surfaced as "needs a budget" in the UI. */
+  needsBudget: boolean;
+};

--- a/lib/utils/entitlements.test.ts
+++ b/lib/utils/entitlements.test.ts
@@ -3,6 +3,7 @@ import {
   FREE_LIMITS,
   canCreateBudget,
   canCreatePocket,
+  canCreateRecurring,
   canInviteMember,
   canScanReceipt,
   canSplitTransactions,
@@ -222,6 +223,31 @@ describe("canCreatePocket", () => {
         account({ plan: "PREMIUM", subscriptionStatus: "ACTIVE" }),
         FREE_LIMITS.maxPockets + 10,
       ).allowed,
+    ).toBe(true);
+  });
+});
+
+describe("canCreateRecurring", () => {
+  it("denies a FREE account even with zero existing templates", () => {
+    const result = canCreateRecurring(account(), 0);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBeTruthy();
+    }
+  });
+
+  it("allows a premium account regardless of template count", () => {
+    expect(
+      canCreateRecurring(
+        account({ plan: "PREMIUM", subscriptionStatus: "ACTIVE" }),
+        50,
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("allows a complimentary account even on the FREE plan", () => {
+    expect(
+      canCreateRecurring(account({ complimentaryAccess: true }), 0).allowed,
     ).toBe(true);
   });
 });

--- a/lib/utils/entitlements.ts
+++ b/lib/utils/entitlements.ts
@@ -16,6 +16,7 @@ export const FREE_LIMITS = {
   maxMembers: 1,
   maxPockets: 3,
   aiReceiptScanning: false,
+  maxRecurringTransactions: 0,
 } as const;
 
 /** Shared shape for every entitlement check below. */
@@ -147,6 +148,30 @@ export const canSplitTransactions = (
     reason:
       "Splitting a transaction across categories is a Premium feature. Upgrade to Premium to split transactions.",
   };
+};
+
+/**
+ * Whether the account may create another recurring transaction template.
+ * Free accounts can't create any (`FREE_LIMITS.maxRecurringTransactions` is
+ * 0); premium (or comped) accounts are unlimited. Free accounts may still
+ * VIEW templates they already have (e.g. after downgrading) — this check
+ * only gates creation, enforced by the CREATE route handler.
+ */
+export const canCreateRecurring = (
+  account: AccountEntitlementFields,
+  currentCount: number,
+): CheckResult => {
+  if (isPremium(account)) return { allowed: true };
+
+  if (currentCount >= FREE_LIMITS.maxRecurringTransactions) {
+    return {
+      allowed: false,
+      reason:
+        "Recurring transactions are a Premium feature. Upgrade to Premium to automate repeating transactions.",
+    };
+  }
+
+  return { allowed: true };
 };
 
 // ---------------------------------------------------------------------------

--- a/lib/utils/recurring.test.ts
+++ b/lib/utils/recurring.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import {
+  addPeriod,
+  computeDueOccurrences,
+  findBudgetForOccurrence,
+  previewUpcomingOccurrences,
+  type BudgetWindow,
+} from "@/lib/utils/recurring";
+
+const d = (iso: string): Date => new Date(iso);
+
+describe("addPeriod", () => {
+  it("adds a day for DAILY", () => {
+    expect(addPeriod(d("2026-01-01T00:00:00.000Z"), "DAILY")).toEqual(
+      d("2026-01-02T00:00:00.000Z"),
+    );
+  });
+
+  it("adds seven days for WEEKLY", () => {
+    expect(addPeriod(d("2026-01-01T00:00:00.000Z"), "WEEKLY")).toEqual(
+      d("2026-01-08T00:00:00.000Z"),
+    );
+  });
+
+  it("adds a month for MONTHLY, rolling over year boundaries", () => {
+    expect(addPeriod(d("2026-12-15T00:00:00.000Z"), "MONTHLY")).toEqual(
+      d("2027-01-15T00:00:00.000Z"),
+    );
+  });
+
+  it("adds three months for QUARTERLY", () => {
+    expect(addPeriod(d("2026-01-31T00:00:00.000Z"), "QUARTERLY")).toEqual(
+      // JS Date rolls Jan 31 + 3 months into May 1 (Apr has 30 days) — this
+      // is the accepted (and documented) behavior of UTC field math.
+      d("2026-05-01T00:00:00.000Z"),
+    );
+  });
+
+  it("adds a year for YEARLY", () => {
+    expect(addPeriod(d("2026-03-10T00:00:00.000Z"), "YEARLY")).toEqual(
+      d("2027-03-10T00:00:00.000Z"),
+    );
+  });
+
+  it("throws for ONE_TIME", () => {
+    expect(() =>
+      addPeriod(d("2026-01-01T00:00:00.000Z"), "ONE_TIME"),
+    ).toThrow();
+  });
+});
+
+describe("computeDueOccurrences", () => {
+  it("returns nothing when nextRunAt is still in the future", () => {
+    const result = computeDueOccurrences(
+      { frequency: "MONTHLY", nextRunAt: d("2026-12-01"), endAt: null },
+      d("2026-06-01"),
+    );
+    expect(result.occurrences).toEqual([]);
+    expect(result.nextRunAt).toEqual(d("2026-12-01"));
+  });
+
+  it("returns a single occurrence when exactly one period is due", () => {
+    const result = computeDueOccurrences(
+      { frequency: "MONTHLY", nextRunAt: d("2026-01-01"), endAt: null },
+      d("2026-01-01"),
+    );
+    expect(result.occurrences).toEqual([d("2026-01-01")]);
+    expect(result.nextRunAt).toEqual(d("2026-02-01"));
+  });
+
+  it("catches up on multiple missed periods", () => {
+    const result = computeDueOccurrences(
+      { frequency: "MONTHLY", nextRunAt: d("2026-01-01"), endAt: null },
+      d("2026-04-15"),
+    );
+    expect(result.occurrences).toEqual([
+      d("2026-01-01"),
+      d("2026-02-01"),
+      d("2026-03-01"),
+      d("2026-04-01"),
+    ]);
+    expect(result.nextRunAt).toEqual(d("2026-05-01"));
+  });
+
+  it("is idempotent — re-running with the advanced pointer yields nothing new", () => {
+    const now = d("2026-04-15");
+    const first = computeDueOccurrences(
+      { frequency: "MONTHLY", nextRunAt: d("2026-01-01"), endAt: null },
+      now,
+    );
+    const second = computeDueOccurrences(
+      { frequency: "MONTHLY", nextRunAt: first.nextRunAt!, endAt: null },
+      now,
+    );
+    expect(second.occurrences).toEqual([]);
+    expect(second.nextRunAt).toEqual(first.nextRunAt);
+  });
+
+  it("caps catch-up at endAt and exhausts the schedule", () => {
+    const result = computeDueOccurrences(
+      {
+        frequency: "MONTHLY",
+        nextRunAt: d("2026-01-01"),
+        endAt: d("2026-02-15"),
+      },
+      d("2026-04-01"),
+    );
+    expect(result.occurrences).toEqual([d("2026-01-01"), d("2026-02-01")]);
+    expect(result.nextRunAt).toBeNull();
+  });
+
+  it("does not include an occurrence landing after endAt", () => {
+    const result = computeDueOccurrences(
+      {
+        frequency: "WEEKLY",
+        nextRunAt: d("2026-01-01"),
+        endAt: d("2026-01-01"),
+      },
+      d("2026-02-01"),
+    );
+    expect(result.occurrences).toEqual([d("2026-01-01")]);
+    expect(result.nextRunAt).toBeNull();
+  });
+
+  it("fires ONE_TIME once when due and reports the schedule exhausted", () => {
+    const result = computeDueOccurrences(
+      { frequency: "ONE_TIME", nextRunAt: d("2026-01-01"), endAt: null },
+      d("2026-03-01"),
+    );
+    expect(result.occurrences).toEqual([d("2026-01-01")]);
+    expect(result.nextRunAt).toBeNull();
+  });
+
+  it("does not fire ONE_TIME before its date", () => {
+    const result = computeDueOccurrences(
+      { frequency: "ONE_TIME", nextRunAt: d("2026-06-01"), endAt: null },
+      d("2026-01-01"),
+    );
+    expect(result.occurrences).toEqual([]);
+    expect(result.nextRunAt).toEqual(d("2026-06-01"));
+  });
+
+  it("handles DAILY catch-up across many missed days", () => {
+    const result = computeDueOccurrences(
+      { frequency: "DAILY", nextRunAt: d("2026-01-01"), endAt: null },
+      d("2026-01-05"),
+    );
+    expect(result.occurrences).toHaveLength(5);
+    expect(result.nextRunAt).toEqual(d("2026-01-06"));
+  });
+});
+
+describe("previewUpcomingOccurrences", () => {
+  it("returns the next N occurrences without mutating the schedule", () => {
+    const schedule = {
+      frequency: "MONTHLY" as const,
+      nextRunAt: d("2026-01-01"),
+      endAt: null,
+    };
+    const preview = previewUpcomingOccurrences(schedule, 3);
+    expect(preview).toEqual([
+      d("2026-01-01"),
+      d("2026-02-01"),
+      d("2026-03-01"),
+    ]);
+    // Unmutated.
+    expect(schedule.nextRunAt).toEqual(d("2026-01-01"));
+  });
+
+  it("stops early at endAt", () => {
+    const preview = previewUpcomingOccurrences(
+      {
+        frequency: "MONTHLY",
+        nextRunAt: d("2026-01-01"),
+        endAt: d("2026-02-15"),
+      },
+      5,
+    );
+    expect(preview).toEqual([d("2026-01-01"), d("2026-02-01")]);
+  });
+
+  it("returns empty when nextRunAt is already past endAt", () => {
+    const preview = previewUpcomingOccurrences(
+      {
+        frequency: "MONTHLY",
+        nextRunAt: d("2026-03-01"),
+        endAt: d("2026-02-01"),
+      },
+      5,
+    );
+    expect(preview).toEqual([]);
+  });
+
+  it("returns a single date for ONE_TIME", () => {
+    const preview = previewUpcomingOccurrences(
+      { frequency: "ONE_TIME", nextRunAt: d("2026-01-01"), endAt: null },
+      5,
+    );
+    expect(preview).toEqual([d("2026-01-01")]);
+  });
+});
+
+describe("findBudgetForOccurrence", () => {
+  const budget = (
+    id: string,
+    startAt: string,
+    endAt: string,
+    status: BudgetWindow["status"] = "ACTIVE",
+  ): BudgetWindow => ({ id, startAt: d(startAt), endAt: d(endAt), status });
+
+  it("finds the budget whose range contains the occurrence date", () => {
+    const budgets = [
+      budget("jan", "2026-01-01", "2026-01-31"),
+      budget("feb", "2026-02-01", "2026-02-28"),
+    ];
+    expect(findBudgetForOccurrence(d("2026-02-15"), budgets)?.id).toBe("feb");
+  });
+
+  it("returns null when no active budget covers the date", () => {
+    const budgets = [budget("jan", "2026-01-01", "2026-01-31")];
+    expect(findBudgetForOccurrence(d("2026-03-01"), budgets)).toBeNull();
+  });
+
+  it("ignores non-ACTIVE budgets even if their range covers the date", () => {
+    const budgets = [
+      budget("archived", "2026-01-01", "2026-12-31", "ARCHIVED"),
+    ];
+    expect(findBudgetForOccurrence(d("2026-06-01"), budgets)).toBeNull();
+  });
+
+  it("picks the latest-starting budget when ranges overlap", () => {
+    const budgets = [
+      budget("old", "2026-01-01", "2026-12-31"),
+      budget("new", "2026-06-01", "2026-12-31"),
+    ];
+    expect(findBudgetForOccurrence(d("2026-07-01"), budgets)?.id).toBe("new");
+  });
+
+  it("treats boundary dates as inclusive", () => {
+    const budgets = [budget("jan", "2026-01-01", "2026-01-31")];
+    expect(findBudgetForOccurrence(d("2026-01-01"), budgets)?.id).toBe("jan");
+    expect(findBudgetForOccurrence(d("2026-01-31"), budgets)?.id).toBe("jan");
+  });
+});

--- a/lib/utils/recurring.ts
+++ b/lib/utils/recurring.ts
@@ -1,0 +1,172 @@
+import type { BudgetStatus, PeriodType } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// Pure, framework-agnostic date math for the recurring-transactions posting
+// engine. Nothing here touches Prisma or the network — see
+// `lib/api-services/recurring.ts` for the DB-backed posting job that calls
+// into these helpers inside a `prisma.$transaction`.
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a recurring template needed for the date math below. */
+export interface RecurringSchedule {
+  frequency: PeriodType;
+  nextRunAt: Date;
+  endAt?: Date | null;
+}
+
+/**
+ * Adds one period to `date` for the given frequency, using UTC field math so
+ * the result is stable regardless of the host timezone (no DST skew).
+ * `ONE_TIME` has no next occurrence — callers must never advance past a
+ * ONE_TIME template's single firing (see `computeDueOccurrences`, which
+ * never calls this for `ONE_TIME`).
+ */
+export const addPeriod = (date: Date, period: PeriodType): Date => {
+  const next = new Date(date.getTime());
+  switch (period) {
+    case "DAILY":
+      next.setUTCDate(next.getUTCDate() + 1);
+      return next;
+    case "WEEKLY":
+      next.setUTCDate(next.getUTCDate() + 7);
+      return next;
+    case "MONTHLY":
+      next.setUTCMonth(next.getUTCMonth() + 1);
+      return next;
+    case "QUARTERLY":
+      next.setUTCMonth(next.getUTCMonth() + 3);
+      return next;
+    case "YEARLY":
+      next.setUTCFullYear(next.getUTCFullYear() + 1);
+      return next;
+    case "ONE_TIME":
+      throw new Error("ONE_TIME schedules have no next occurrence");
+  }
+};
+
+export interface DueOccurrencesResult {
+  /** Every occurrence date due to post, oldest first, catching up on any
+   * periods missed since the schedule was last run. */
+  occurrences: Date[];
+  /**
+   * Where `nextRunAt` should be advanced to after posting every occurrence
+   * above. `null` means the schedule is exhausted — either a `ONE_TIME`
+   * template just fired, or `endAt` has been passed — and the template
+   * should be paused rather than rescheduled.
+   */
+  nextRunAt: Date | null;
+}
+
+/**
+ * Computes every occurrence due between a template's stored `nextRunAt` and
+ * `now` (inclusive), capped at `endAt` when set, plus the pointer `nextRunAt`
+ * should advance to afterward.
+ *
+ * This is the whole idempotency contract for the posting engine: calling it
+ * twice with the same `nextRunAt` and `now` always returns the same
+ * occurrences, and once the caller persists the returned `nextRunAt` back
+ * onto the template, a repeat call (e.g. a retried cron run) with the
+ * now-advanced `nextRunAt` returns an empty `occurrences` list. No separate
+ * "already posted" ledger is needed — the pointer IS the guard (the caller
+ * additionally gets a uniqueness safeguard for free via the
+ * `(recurringTransactionId, occurredAt)` unique index, in case two runs
+ * somehow race before either persists its pointer update).
+ *
+ * `ONE_TIME` fires once (if due) and then reports `nextRunAt: null`.
+ */
+export const computeDueOccurrences = (
+  schedule: RecurringSchedule,
+  now: Date,
+): DueOccurrencesResult => {
+  const occurrences: Date[] = [];
+  let cursor: Date | null = schedule.nextRunAt;
+
+  while (cursor !== null && cursor.getTime() <= now.getTime()) {
+    if (schedule.endAt && cursor.getTime() > schedule.endAt.getTime()) {
+      cursor = null;
+      break;
+    }
+
+    occurrences.push(cursor);
+    cursor =
+      schedule.frequency === "ONE_TIME"
+        ? null
+        : addPeriod(cursor, schedule.frequency);
+  }
+
+  // The pointer may have advanced past `endAt` without ever being <= `now`
+  // (e.g. the last catch-up occurrence lands exactly on `endAt`, so the
+  // period after it is already out of range) — cap it here too so a
+  // schedule never lingers with a pointer that can never fire again.
+  if (
+    cursor !== null &&
+    schedule.endAt &&
+    cursor.getTime() > schedule.endAt.getTime()
+  ) {
+    cursor = null;
+  }
+
+  return { occurrences, nextRunAt: cursor };
+};
+
+/**
+ * Previews up to `count` upcoming occurrence dates from a template's current
+ * `nextRunAt`, without mutating anything — used by the management UI to show
+ * "next 3 occurrences" style copy. Stops early at `endAt` when set.
+ */
+export const previewUpcomingOccurrences = (
+  schedule: RecurringSchedule,
+  count: number,
+): Date[] => {
+  if (
+    schedule.endAt &&
+    schedule.nextRunAt.getTime() > schedule.endAt.getTime()
+  ) {
+    return [];
+  }
+
+  if (schedule.frequency === "ONE_TIME") {
+    return [schedule.nextRunAt];
+  }
+
+  const dates: Date[] = [];
+  let cursor = schedule.nextRunAt;
+  while (dates.length < count) {
+    if (schedule.endAt && cursor.getTime() > schedule.endAt.getTime()) break;
+    dates.push(cursor);
+    cursor = addPeriod(cursor, schedule.frequency);
+  }
+  return dates;
+};
+
+/** Minimal shape of a budget needed to resolve which one an occurrence lands in. */
+export interface BudgetWindow {
+  id: string;
+  status: BudgetStatus;
+  startAt: Date;
+  endAt: Date;
+}
+
+/**
+ * Finds the ACTIVE budget whose `[startAt, endAt]` range contains
+ * `occurrenceDate`, or `null` if none does — the "needs a budget" hold case.
+ * When more than one active budget's range contains the date (shouldn't
+ * normally happen, but budgets aren't required to be non-overlapping), the
+ * one with the latest `startAt` wins, matching "the current period" intent.
+ */
+export const findBudgetForOccurrence = <B extends BudgetWindow>(
+  occurrenceDate: Date,
+  budgets: readonly B[],
+): B | null => {
+  const candidates = budgets.filter(
+    (b) =>
+      b.status === "ACTIVE" &&
+      b.startAt.getTime() <= occurrenceDate.getTime() &&
+      occurrenceDate.getTime() <= b.endAt.getTime(),
+  );
+  if (candidates.length === 0) return null;
+
+  return candidates.reduce((latest, candidate) =>
+    candidate.startAt.getTime() > latest.startAt.getTime() ? candidate : latest,
+  );
+};

--- a/lib/utils/transactions.ts
+++ b/lib/utils/transactions.ts
@@ -46,6 +46,15 @@ export const SPLIT_BADGE_CLASSES = "bg-accent text-primary";
 export const getSplitBadgeLabel = (splitCount: number): string =>
   `Split · ${splitCount} categor${splitCount === 1 ? "y" : "ies"}`;
 
+/**
+ * Badge classes for the small "Recurring" indicator shown next to a
+ * transaction that was auto-posted by the recurring-transactions engine
+ * (`transaction.recurringTransactionId` set — see
+ * lib/api-services/recurring.ts). Secondary tint since it's metadata about
+ * the transaction's origin, not a category or status.
+ */
+export const RECURRING_BADGE_CLASSES = "bg-secondary-50 text-secondary-700";
+
 export interface TransactionFilters {
   /** Free-text search across name, description, category and amount. */
   searchTerm: string;

--- a/prisma/migrations/20260706140000_add_recurring_transactions/migration.sql
+++ b/prisma/migrations/20260706140000_add_recurring_transactions/migration.sql
@@ -1,0 +1,67 @@
+-- AlterTable
+ALTER TABLE "transactions" ADD COLUMN     "recurringTransactionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "recurring_transactions" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "description" TEXT,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "transactionType" "TransactionType" NOT NULL DEFAULT 'REGULAR',
+    "categoryId" TEXT,
+    "cardId" TEXT,
+    "accountId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "frequency" "PeriodType" NOT NULL,
+    "nextRunAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3),
+    "paused" BOOLEAN NOT NULL DEFAULT false,
+    "deleted" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "recurring_transactions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_accountId_idx" ON "recurring_transactions"("accountId");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_userId_idx" ON "recurring_transactions"("userId");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_categoryId_idx" ON "recurring_transactions"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_cardId_idx" ON "recurring_transactions"("cardId");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_nextRunAt_idx" ON "recurring_transactions"("nextRunAt");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_paused_idx" ON "recurring_transactions"("paused");
+
+-- CreateIndex
+CREATE INDEX "recurring_transactions_deleted_idx" ON "recurring_transactions"("deleted");
+
+-- CreateIndex
+CREATE INDEX "transactions_recurringTransactionId_idx" ON "transactions"("recurringTransactionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "transactions_recurringTransactionId_occurredAt_key" ON "transactions"("recurringTransactionId", "occurredAt");
+
+-- AddForeignKey
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_recurringTransactionId_fkey" FOREIGN KEY ("recurringTransactionId") REFERENCES "recurring_transactions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recurring_transactions" ADD CONSTRAINT "recurring_transactions_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recurring_transactions" ADD CONSTRAINT "recurring_transactions_cardId_fkey" FOREIGN KEY ("cardId") REFERENCES "card"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recurring_transactions" ADD CONSTRAINT "recurring_transactions_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recurring_transactions" ADD CONSTRAINT "recurring_transactions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,351 +2,416 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-    provider = "postgresql"
-    // NOTE: When using mysql or sqlserver, uncomment the @db.Text annotations in model Account below
-    // Further reading:
-    // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
-    // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
-    url      = env("DATABASE_URL")
+  provider = "postgresql"
+  // NOTE: When using mysql or sqlserver, uncomment the @db.Text annotations in model Account below
+  // Further reading:
+  // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
+  // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
+  url      = env("DATABASE_URL")
 }
 
 model Account {
-    id                   String              @id @default(cuid())
-    name                 String
-    users                AccountUser[]
-    budgets              Budget[]
-    deleted              DateTime?
-    createdAt            DateTime            @default(now())
-    updatedAt            DateTime            @updatedAt
-    transactions         Transaction[]
-    savings              Savings[]
-    plan                 Plan                @default(FREE)
-    complimentaryAccess  Boolean             @default(false)
-    stripeCustomerId     String?             @unique
-    stripeSubscriptionId String?             @unique
-    subscriptionStatus   SubscriptionStatus?
-    currentPeriodEnd     DateTime?
-    // Account-wide module on/off preferences (see lib/types/feature-settings.ts).
-    // JSON so new toggleable modules don't require a migration later. Null
-    // means "never configured" — callers must merge over
-    // DEFAULT_FEATURE_SETTINGS via parseFeatureSettings, never read raw.
-    featureSettings      Json?
+  id                    String                 @id @default(cuid())
+  name                  String
+  users                 AccountUser[]
+  budgets               Budget[]
+  deleted               DateTime?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
+  transactions          Transaction[]
+  savings               Savings[]
+  recurringTransactions RecurringTransaction[]
+  plan                  Plan                   @default(FREE)
+  complimentaryAccess   Boolean                @default(false)
+  stripeCustomerId      String?                @unique
+  stripeSubscriptionId  String?                @unique
+  subscriptionStatus    SubscriptionStatus?
+  currentPeriodEnd      DateTime?
+  // Account-wide module on/off preferences (see lib/types/feature-settings.ts).
+  // JSON so new toggleable modules don't require a migration later. Null
+  // means "never configured" — callers must merge over
+  // DEFAULT_FEATURE_SETTINGS via parseFeatureSettings, never read raw.
+  featureSettings       Json?
 
-    @@index([id])
-    @@index([name])
-    @@index([deleted])
-    @@map("accounts")
+  @@index([id])
+  @@index([name])
+  @@index([deleted])
+  @@map("accounts")
 }
 
 model AccountUser {
-    id        String  @id @default(cuid())
-    accountId String
-    userId    String
-    account   Account @relation(fields: [accountId], references: [id])
-    user      User    @relation(fields: [userId], references: [id])
+  id        String  @id @default(cuid())
+  accountId String
+  userId    String
+  account   Account @relation(fields: [accountId], references: [id])
+  user      User    @relation(fields: [userId], references: [id])
 
-    @@index([accountId])
-    @@index([userId])
-    @@map("account_user")
+  @@index([accountId])
+  @@index([userId])
+  @@map("account_user")
 }
 
 model User {
-    id            String        @id @default(cuid())
-    name          String
-    firstName     String
-    lastName      String
-    email         String?       @unique
-    password      String?
-    emailVerified DateTime?
-    role          Role?
-    phone         String?
-    image         String?
-    theme         String        @default("system")
-    cards         Card[]
-    deleted       DateTime?
-    createdAt     DateTime      @default(now())
-    updatedAt     DateTime      @updatedAt
-    sessions      Session[]
-    accountUsers  AccountUser[]
-    transactions  Transaction[]
-    savings       Savings[]
-    allocations   Allocation[]
+  id                    String                 @id @default(cuid())
+  name                  String
+  firstName             String
+  lastName              String
+  email                 String?                @unique
+  password              String?
+  emailVerified         DateTime?
+  role                  Role?
+  phone                 String?
+  image                 String?
+  theme                 String                 @default("system")
+  cards                 Card[]
+  deleted               DateTime?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
+  sessions              Session[]
+  accountUsers          AccountUser[]
+  transactions          Transaction[]
+  savings               Savings[]
+  allocations           Allocation[]
+  recurringTransactions RecurringTransaction[]
 
-    @@index([email])
-    @@index([name])
-    @@index([role])
-    @@map("users")
+  @@index([email])
+  @@index([name])
+  @@index([role])
+  @@map("users")
 }
 
 model VerificationToken {
-    identifier String
-    token      String   @unique
-    expires    DateTime
+  identifier String
+  token      String   @unique
+  expires    DateTime
 
-    @@unique([identifier, token])
-    @@map("verification_tokens")
+  @@unique([identifier, token])
+  @@map("verification_tokens")
 }
 
 model Session {
-    id           String   @id @default(cuid())
-    sessionToken String   @unique
-    userId       String
-    expires      DateTime
-    user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-    @@index([userId])
-    @@map("sessions")
+  @@index([userId])
+  @@map("sessions")
 }
 
 model Budget {
-    id           String        @id @default(cuid())
-    name         String
-    strategy     StrategyType
-    period       PeriodType
-    status       BudgetStatus  @default(ACTIVE)
-    deleted      DateTime?
-    startAt      DateTime
-    endAt        DateTime
-    createdAt    DateTime      @default(now())
-    updatedAt    DateTime      @updatedAt
-    accountId    String
-    account      Account       @relation(fields: [accountId], references: [id])
-    categories   Category[]
-    transactions Transaction[]
-    cards        Card[]
+  id           String        @id @default(cuid())
+  name         String
+  strategy     StrategyType
+  period       PeriodType
+  status       BudgetStatus  @default(ACTIVE)
+  deleted      DateTime?
+  startAt      DateTime
+  endAt        DateTime
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  accountId    String
+  account      Account       @relation(fields: [accountId], references: [id])
+  categories   Category[]
+  transactions Transaction[]
+  cards        Card[]
 
-    @@index([id])
-    @@index([name])
-    @@index([strategy])
-    @@index([period])
-    @@index([status])
-    @@index([deleted])
-    @@map("budgets")
+  @@index([id])
+  @@index([name])
+  @@index([strategy])
+  @@index([period])
+  @@index([status])
+  @@index([deleted])
+  @@map("budgets")
 }
 
 model Category {
-    id                String        @id @default(cuid())
-    budgetId          String?
-    budget            Budget?       @relation(fields: [budgetId], references: [id])
-    defaultCategoryId String?
-    defaultCategory   Category?     @relation("DefaultCategory", fields: [defaultCategoryId], references: [id])
-    budgetCategories  Category[]    @relation("DefaultCategory")
-    name              String
-    group             CategoryType
-    allocatedAmount   Float?
-    transactions      Transaction[]
-    transactionSplits TransactionSplit[]
-    createdAt         DateTime      @default(now())
-    updatedAt         DateTime      @updatedAt
-    deleted           DateTime?
+  id                    String                 @id @default(cuid())
+  budgetId              String?
+  budget                Budget?                @relation(fields: [budgetId], references: [id])
+  defaultCategoryId     String?
+  defaultCategory       Category?              @relation("DefaultCategory", fields: [defaultCategoryId], references: [id])
+  budgetCategories      Category[]             @relation("DefaultCategory")
+  name                  String
+  group                 CategoryType
+  allocatedAmount       Float?
+  transactions          Transaction[]
+  transactionSplits     TransactionSplit[]
+  recurringTransactions RecurringTransaction[]
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
+  deleted               DateTime?
 
-    @@index([id])
-    @@index([budgetId])
-    @@index([defaultCategoryId])
-    @@index([deleted])
-    @@map("category")
+  @@index([id])
+  @@index([budgetId])
+  @@index([defaultCategoryId])
+  @@index([deleted])
+  @@map("category")
 }
 
 model Card {
-    id             String        @id @default(cuid())
-    name           String
-    lastFourDigits String?
-    cardType       CardType
-    amountSpent    Float?
-    spendingLimit  Float?
-    budgetId       String?
-    budget         Budget?       @relation(fields: [budgetId], references: [id])
-    defaultCardId  String?
-    defaultCard    Card?         @relation("DefaultCard", fields: [defaultCardId], references: [id])
-    budgetCards    Card[]        @relation("DefaultCard")
-    userId         String
-    user           User          @relation(fields: [userId], references: [id])
-    transactions   Transaction[]
-    deleted        DateTime?
-    createdAt      DateTime      @default(now())
-    updatedAt      DateTime      @updatedAt
+  id                    String                 @id @default(cuid())
+  name                  String
+  lastFourDigits        String?
+  cardType              CardType
+  amountSpent           Float?
+  spendingLimit         Float?
+  budgetId              String?
+  budget                Budget?                @relation(fields: [budgetId], references: [id])
+  defaultCardId         String?
+  defaultCard           Card?                  @relation("DefaultCard", fields: [defaultCardId], references: [id])
+  budgetCards           Card[]                 @relation("DefaultCard")
+  userId                String
+  user                  User                   @relation(fields: [userId], references: [id])
+  transactions          Transaction[]
+  recurringTransactions RecurringTransaction[]
+  deleted               DateTime?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @updatedAt
 
-    @@index([id])
-    @@index([defaultCardId])
-    @@map("card")
+  @@index([id])
+  @@index([defaultCardId])
+  @@map("card")
 }
 
 model Transaction {
-    id                  String          @id @default(cuid())
-    name                String?
-    description         String?
-    amount              Float
-    occurredAt          DateTime?
-    createdAt           DateTime        @default(now())
-    updatedAt           DateTime        @updatedAt
-    deleted             DateTime?
-    cardId              String?
-    card                Card?           @relation(fields: [cardId], references: [id])
-    budgetId            String
-    Budget              Budget          @relation(fields: [budgetId], references: [id])
-    categoryId          String?
-    category            Category?       @relation(fields: [categoryId], references: [id])
-    accountId           String
-    account             Account         @relation(fields: [accountId], references: [id])
-    userId              String
-    user                User            @relation(fields: [userId], references: [id])
-    transactionType     TransactionType @default(REGULAR)
-    linkedTransactionId String?
-    linkedTransaction   Transaction?    @relation("LinkedTransactions", fields: [linkedTransactionId], references: [id])
-    linkedTransactions  Transaction[]   @relation("LinkedTransactions")
-    splits              TransactionSplit[]
+  id                     String                @id @default(cuid())
+  name                   String?
+  description            String?
+  amount                 Float
+  occurredAt             DateTime?
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+  deleted                DateTime?
+  cardId                 String?
+  card                   Card?                 @relation(fields: [cardId], references: [id])
+  budgetId               String
+  Budget                 Budget                @relation(fields: [budgetId], references: [id])
+  categoryId             String?
+  category               Category?             @relation(fields: [categoryId], references: [id])
+  accountId              String
+  account                Account               @relation(fields: [accountId], references: [id])
+  userId                 String
+  user                   User                  @relation(fields: [userId], references: [id])
+  transactionType        TransactionType       @default(REGULAR)
+  linkedTransactionId    String?
+  linkedTransaction      Transaction?          @relation("LinkedTransactions", fields: [linkedTransactionId], references: [id])
+  linkedTransactions     Transaction[]         @relation("LinkedTransactions")
+  splits                 TransactionSplit[]
+  // Set when this transaction was auto-posted by the recurring-transactions
+  // engine (see lib/api-services/recurring.ts). `occurredAt` is always set
+  // to the occurrence date for these rows, and the (recurringTransactionId,
+  // occurredAt) pair is unique so the same occurrence can never be posted
+  // twice, even if the posting job runs concurrently or is retried.
+  recurringTransactionId String?
+  recurringTransaction   RecurringTransaction? @relation(fields: [recurringTransactionId], references: [id])
 
-    @@index([id])
-    @@index([name])
-    @@index([amount])
-    @@index([deleted])
-    @@index([transactionType])
-    @@map("transactions")
+  @@unique([recurringTransactionId, occurredAt])
+  @@index([id])
+  @@index([name])
+  @@index([amount])
+  @@index([deleted])
+  @@index([transactionType])
+  @@index([recurringTransactionId])
+  @@map("transactions")
 }
 
 model TransactionSplit {
-    id            String      @id @default(cuid())
-    transactionId String
-    transaction   Transaction @relation(fields: [transactionId], references: [id], onDelete: Cascade)
-    categoryId    String
-    category      Category    @relation(fields: [categoryId], references: [id])
-    amount        Float
-    note          String?
+  id            String      @id @default(cuid())
+  transactionId String
+  transaction   Transaction @relation(fields: [transactionId], references: [id], onDelete: Cascade)
+  categoryId    String
+  category      Category    @relation(fields: [categoryId], references: [id])
+  amount        Float
+  note          String?
 
-    @@index([transactionId])
-    @@index([categoryId])
-    @@map("transaction_splits")
+  @@index([transactionId])
+  @@index([categoryId])
+  @@map("transaction_splits")
+}
+
+// A repeating-transaction template (rent, subscriptions, paychecks, etc).
+// The posting engine (lib/utils/recurring.ts + lib/api-services/recurring.ts)
+// walks `nextRunAt` forward and materializes each due occurrence as a real
+// `Transaction` (linked back via `Transaction.recurringTransactionId`) in the
+// ACTIVE budget whose date range contains the occurrence date. If no such
+// budget exists yet, the occurrence is held — `nextRunAt` simply doesn't
+// advance past it — until one does. Premium-gated to create (see
+// `canCreateRecurring` in lib/utils/entitlements.ts); free accounts may still
+// view templates they already have (e.g. after a downgrade).
+model RecurringTransaction {
+  id              String          @id @default(cuid())
+  name            String?
+  description     String?
+  amount          Float
+  transactionType TransactionType @default(REGULAR)
+  categoryId      String?
+  category        Category?       @relation(fields: [categoryId], references: [id])
+  cardId          String?
+  card            Card?           @relation(fields: [cardId], references: [id])
+  accountId       String
+  account         Account         @relation(fields: [accountId], references: [id])
+  userId          String
+  user            User            @relation(fields: [userId], references: [id])
+  // How often this template fires. ONE_TIME posts a single occurrence at
+  // `nextRunAt` and then never runs again (see addPeriod in recurring.ts).
+  frequency       PeriodType
+  // The next occurrence date due to post. Advances by one period each time
+  // an occurrence is successfully posted; this pointer (not a separate log)
+  // is the idempotency guard for the posting engine.
+  nextRunAt       DateTime
+  // Optional last occurrence date — occurrences past this are never posted
+  // and the schedule is considered exhausted.
+  endAt           DateTime?
+  // User-controlled pause. Also set `true` internally once a schedule is
+  // exhausted (ONE_TIME fired, or `endAt` reached), so it doubles as a
+  // "done" flag — paused templates are simply skipped by the poster.
+  paused          Boolean         @default(false)
+  transactions    Transaction[]
+  deleted         DateTime?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  @@index([accountId])
+  @@index([userId])
+  @@index([categoryId])
+  @@index([cardId])
+  @@index([nextRunAt])
+  @@index([paused])
+  @@index([deleted])
+  @@map("recurring_transactions")
 }
 
 model Savings {
-    id        String    @id @default(cuid())
-    name      String
-    accountId String
-    account   Account   @relation(fields: [accountId], references: [id])
-    userId    String
-    user      User      @relation(fields: [userId], references: [id])
-    pockets   Pocket[]
-    deleted   DateTime?
-    createdAt DateTime  @default(now())
-    updatedAt DateTime  @updatedAt
+  id        String    @id @default(cuid())
+  name      String
+  accountId String
+  account   Account   @relation(fields: [accountId], references: [id])
+  userId    String
+  user      User      @relation(fields: [userId], references: [id])
+  pockets   Pocket[]
+  deleted   DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
-    @@index([accountId])
-    @@index([userId])
-    @@index([deleted])
-    @@map("savings")
+  @@index([accountId])
+  @@index([userId])
+  @@index([deleted])
+  @@map("savings")
 }
 
 model Pocket {
-    id          String       @id @default(cuid())
-    savingsId   String
-    savings     Savings      @relation(fields: [savingsId], references: [id])
-    name        String
-    goalAmount  Float?
-    goalDate    DateTime?
-    goalNote    String?
-    allocations Allocation[]
-    deleted     DateTime?
-    createdAt   DateTime     @default(now())
-    updatedAt   DateTime     @updatedAt
+  id          String       @id @default(cuid())
+  savingsId   String
+  savings     Savings      @relation(fields: [savingsId], references: [id])
+  name        String
+  goalAmount  Float?
+  goalDate    DateTime?
+  goalNote    String?
+  allocations Allocation[]
+  deleted     DateTime?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
 
-    @@index([savingsId])
-    @@index([deleted])
-    @@map("pocket")
+  @@index([savingsId])
+  @@index([deleted])
+  @@map("pocket")
 }
 
 model Allocation {
-    id         String    @id @default(cuid())
-    pocketId   String
-    pocket     Pocket    @relation(fields: [pocketId], references: [id])
-    userId     String
-    user       User      @relation(fields: [userId], references: [id])
-    amount     Float
-    withdrawal Boolean   @default(false)
-    note       String?
-    occurredAt DateTime?
-    createdAt  DateTime  @default(now())
-    updatedAt  DateTime  @default(now()) @updatedAt
+  id         String    @id @default(cuid())
+  pocketId   String
+  pocket     Pocket    @relation(fields: [pocketId], references: [id])
+  userId     String
+  user       User      @relation(fields: [userId], references: [id])
+  amount     Float
+  withdrawal Boolean   @default(false)
+  note       String?
+  occurredAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
 
-    @@index([pocketId])
-    @@index([userId])
-    @@map("allocation")
+  @@index([pocketId])
+  @@index([userId])
+  @@map("allocation")
 }
 
 enum Role {
-    ADMIN
-    MEMBER
+  ADMIN
+  MEMBER
 }
 
 enum StrategyType {
-    ZERO_SUM
-    FIFTY_THIRTY_TWENTY
+  ZERO_SUM
+  FIFTY_THIRTY_TWENTY
 }
 
 enum PeriodType {
-    DAILY
-    WEEKLY
-    MONTHLY
-    QUARTERLY
-    YEARLY
-    ONE_TIME
+  DAILY
+  WEEKLY
+  MONTHLY
+  QUARTERLY
+  YEARLY
+  ONE_TIME
 }
 
 enum CardType {
-    CASH
-    DEBIT
-    CREDIT
-    BUSINESS_DEBIT
-    BUSINESS_CREDIT
+  CASH
+  DEBIT
+  CREDIT
+  BUSINESS_DEBIT
+  BUSINESS_CREDIT
 }
 
 enum CategoryType {
-    WANTS
-    NEEDS
-    INVESTMENT
+  WANTS
+  NEEDS
+  INVESTMENT
 }
 
 enum TransactionType {
-    REGULAR
-    RETURN
-    CARD_PAYMENT
-    INCOME
+  REGULAR
+  RETURN
+  CARD_PAYMENT
+  INCOME
 }
 
 enum BudgetStatus {
-    ACTIVE
-    COMPLETED
-    ARCHIVED
+  ACTIVE
+  COMPLETED
+  ARCHIVED
 }
 
 enum Plan {
-    FREE
-    PREMIUM
+  FREE
+  PREMIUM
 }
 
 enum SubscriptionStatus {
-    ACTIVE
-    PAST_DUE
-    CANCELED
+  ACTIVE
+  PAST_DUE
+  CANCELED
 }
 
 enum EmailTokenPurpose {
-    PASSWORD_RESET
-    LOGIN_CODE
+  PASSWORD_RESET
+  LOGIN_CODE
 }
 
 model EmailToken {
-    id        String            @id @default(cuid())
-    email     String
-    tokenHash String
-    purpose   EmailTokenPurpose
-    expires   DateTime
-    attempts  Int               @default(0)
-    createdAt DateTime          @default(now())
+  id        String            @id @default(cuid())
+  email     String
+  tokenHash String
+  purpose   EmailTokenPurpose
+  expires   DateTime
+  attempts  Int               @default(0)
+  createdAt DateTime          @default(now())
 
-    @@unique([email, purpose])
-    @@map("email_tokens")
+  @@unique([email, purpose])
+  @@map("email_tokens")
 }

--- a/src/app/api/cron/recurring/route.ts
+++ b/src/app/api/cron/recurring/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { env } from "@/env";
+import prisma from "@/lib/prisma";
+import { postDueRecurringTransactionsForAccount } from "@/lib/api-services/recurring";
+
+/**
+ * Daily cron entry point (see vercel.json) that posts every due recurring
+ * transaction across every account. Vercel Cron automatically sends
+ * `Authorization: Bearer ${CRON_SECRET}` when the CRON_SECRET env var is set
+ * (see src/env.js), so this route just verifies that header matches.
+ *
+ * Each account is processed in its own `prisma.$transaction` (rather than one
+ * transaction spanning every account) so a large account list can't hold one
+ * long-lived lock, and one account's failure doesn't roll back another's.
+ */
+export async function GET(req: NextRequest) {
+  if (!env.CRON_SECRET) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+
+  const dueAccounts = await prisma.recurringTransaction.findMany({
+    where: { deleted: null, paused: false, nextRunAt: { lte: now } },
+    distinct: ["accountId"],
+    select: { accountId: true },
+  });
+
+  const results = [];
+  for (const { accountId } of dueAccounts) {
+    const summaries = await prisma.$transaction((tx) =>
+      postDueRecurringTransactionsForAccount(tx, accountId, now),
+    );
+    results.push({
+      accountId,
+      posted: summaries.reduce((sum, s) => sum + s.posted, 0),
+      summaries,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      accountsProcessed: results.length,
+      totalPosted: results.reduce((sum, r) => sum + r.posted, 0),
+      results,
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/recurring/[id]/route.ts
+++ b/src/app/api/recurring/[id]/route.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { updateRecurringTransactionSchema } from "@/lib/api-schemas/recurring";
+import {
+  updateRecurringTransaction,
+  deleteRecurringTransaction,
+} from "@/lib/api-services/recurring";
+import {
+  getAccountEntitlements,
+  paymentRequired,
+  RECURRING_LOCKED_REASON,
+} from "@/lib/api-services/entitlements";
+import { isPremium } from "@/lib/utils/entitlements";
+
+// Recurring transactions are view-only on the Free plan — this covers
+// editing fields, pausing/resuming (via `paused` in the body), and deleting.
+// Templates a downgraded account already had stay visible in GET, just
+// read-only, until the account is premium again.
+export const PATCH = withUser({
+  PATCH: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const { id } = await context.params;
+      const body = (await req.json()) as unknown;
+      const parsed = updateRecurringTransactionSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { message: "Validation failed", errors: parsed.error.errors },
+          { status: 400 },
+        );
+      }
+
+      const account = await getAccountEntitlements(prisma, user.accountId);
+      if (!isPremium(account)) {
+        return paymentRequired(RECURRING_LOCKED_REASON);
+      }
+
+      const template = await prisma.$transaction((tx) =>
+        updateRecurringTransaction(tx, id!, parsed.data, user),
+      );
+      return NextResponse.json(template, { status: 200 });
+    },
+  ),
+});
+
+export const DELETE = withUser({
+  DELETE: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const { id } = await context.params;
+
+      const account = await getAccountEntitlements(prisma, user.accountId);
+      if (!isPremium(account)) {
+        return paymentRequired(RECURRING_LOCKED_REASON);
+      }
+
+      await prisma.$transaction((tx) =>
+        deleteRecurringTransaction(tx, id!, user),
+      );
+      return NextResponse.json({ success: true }, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/recurring/catch-up/route.ts
+++ b/src/app/api/recurring/catch-up/route.ts
@@ -1,0 +1,32 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { postDueRecurringTransactionsForAccount } from "@/lib/api-services/recurring";
+
+/**
+ * Lazy, on-app-load substitute for the cron job (`/api/cron/recurring`) —
+ * posts any due recurring occurrences for the CURRENT user's account. Called
+ * once per session by `useRecurringCatchUp` (see
+ * lib/data-hooks/recurring/useRecurringCatchUp.ts) so self-hosted/dev setups
+ * without cron configured still get recurring transactions posted, just on
+ * next visit rather than exactly on schedule. Cheap (no-op when nothing is
+ * due) and idempotent (same guarantee as the cron job — see
+ * postDueRecurringTransactionsForAccount).
+ */
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const summaries = await prisma.$transaction((tx) =>
+        postDueRecurringTransactionsForAccount(tx, user.accountId),
+      );
+      const posted = summaries.reduce((sum, s) => sum + s.posted, 0);
+      return NextResponse.json({ posted, summaries }, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/recurring/route.ts
+++ b/src/app/api/recurring/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { createRecurringTransactionSchema } from "@/lib/api-schemas/recurring";
+import {
+  getRecurringTransactions,
+  createRecurringTransaction,
+} from "@/lib/api-services/recurring";
+import {
+  getAccountEntitlements,
+  paymentRequired,
+} from "@/lib/api-services/entitlements";
+import { canCreateRecurring } from "@/lib/utils/entitlements";
+
+// Free accounts may still view their existing recurring templates (e.g.
+// after downgrading) — only creation is gated, in POST below.
+export const GET = withUser({
+  GET: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const templates = await prisma.$transaction((tx) =>
+        getRecurringTransactions(tx, user.accountId),
+      );
+      return NextResponse.json(templates, { status: 200 });
+    },
+  ),
+});
+
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = (await req.json()) as unknown;
+      const parsed = createRecurringTransactionSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { message: "Validation failed", errors: parsed.error.errors },
+          { status: 400 },
+        );
+      }
+
+      const account = await getAccountEntitlements(prisma, user.accountId);
+      const currentCount = await prisma.recurringTransaction.count({
+        where: { accountId: user.accountId, deleted: null },
+      });
+      const entitlementCheck = canCreateRecurring(account, currentCount);
+      if (!entitlementCheck.allowed) {
+        return paymentRequired(entitlementCheck.reason);
+      }
+
+      const template = await prisma.$transaction((tx) =>
+        createRecurringTransaction(tx, parsed.data, user),
+      );
+      return NextResponse.json(template, { status: 201 });
+    },
+  ),
+});

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -29,6 +29,7 @@ import {
   SlidersHorizontal,
   ScanLine,
   ChevronDown,
+  Repeat,
 } from "lucide-react";
 import PageHeader from "@/components/PageHeader";
 import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
@@ -38,6 +39,7 @@ import { useMobileHeaderAction } from "@/components/MobileHeaderActionContext";
 import AddTransactionModal from "@/components/transactions/AddTransactionModal";
 import ReceiptScanModal from "@/components/transactions/ReceiptScanModal";
 import InlineTransactionEdit from "@/components/transactions/InlineTransactionEdit";
+import TransactionsPageNavigation from "@/components/transactions/TransactionsPageNavigation";
 import TransactionFiltersModal, {
   type TransactionFilterValues,
   type TransactionSortBy,
@@ -56,6 +58,7 @@ import {
   matchesTransactionFilters,
   SPLIT_BADGE_CLASSES,
   getSplitBadgeLabel,
+  RECURRING_BADGE_CLASSES,
 } from "@/lib/utils/transactions";
 
 // URL param scheme (only non-default values are written to the URL):
@@ -630,6 +633,8 @@ const TransactionsPageContent = () => {
         ]}
       />
 
+      <TransactionsPageNavigation />
+
       <div className="pt-4 lg:flex-1 lg:overflow-hidden lg:pt-0">
         <div className="lg:h-full lg:overflow-y-auto">
           <div className="mx-auto w-full px-2 py-4 pb-28 sm:px-4 sm:py-6 sm:pb-28 lg:px-8 lg:py-4 lg:pb-8">
@@ -903,6 +908,15 @@ const TransactionsPageContent = () => {
                                       : (transaction.category?.name ??
                                         "No Category")}
                                 </span>
+                                {transaction.recurringTransactionId && (
+                                  <span
+                                    className={`inline-flex flex-shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${RECURRING_BADGE_CLASSES}`}
+                                    title="Auto-posted from a recurring transaction"
+                                  >
+                                    <Repeat className="h-3 w-3" />
+                                    Recurring
+                                  </span>
+                                )}
                                 {transaction.description && (
                                   <div className="group relative flex-shrink-0">
                                     <Info className="h-4 w-4 cursor-help text-gray-400" />

--- a/src/app/transactions/recurring/page.tsx
+++ b/src/app/transactions/recurring/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+import {
+  Repeat,
+  Plus,
+  Pause,
+  Play,
+  Pencil,
+  Trash2,
+  AlertTriangle,
+  Lock,
+} from "lucide-react";
+import PageHeader from "@/components/PageHeader";
+import TransactionsPageNavigation from "@/components/transactions/TransactionsPageNavigation";
+import RecurringTransactionForm from "@/components/transactions/RecurringTransactionForm";
+import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
+import UpgradeModal from "@/components/UpgradeModal";
+import FeatureDisabledState from "@/components/FeatureDisabledState";
+import Button from "@/components/Button";
+import { usePageLoading } from "@/components/ConditionalLayout";
+import { useIsFeatureEnabled } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { useBillingStatus } from "@/lib/data-hooks/billing/useBilling";
+import {
+  useDeleteRecurringTransaction,
+  useRecurringTransactions,
+  useToggleRecurringTransactionPaused,
+} from "@/lib/data-hooks/recurring/useRecurring";
+import type { RecurringTransactionWithRelations } from "@/lib/types/recurring";
+import { formatCurrency, getCategoryBadgeColor } from "@/lib/utils";
+import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
+
+const RECURRING_UPGRADE_REASON =
+  "Recurring transactions are a Premium feature. Upgrade to Premium to automate repeating transactions.";
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  DAILY: "Daily",
+  WEEKLY: "Weekly",
+  MONTHLY: "Monthly",
+  QUARTERLY: "Quarterly",
+  YEARLY: "Yearly",
+  ONE_TIME: "One time",
+};
+
+const formatOccurrenceDate = (value: string | Date): string =>
+  new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+export default function RecurringTransactionsPage() {
+  const recurringEnabled = useIsFeatureEnabled("recurringTransactions");
+  const { data: templates = [], isLoading } = useRecurringTransactions();
+  const { data: billingStatus } = useBillingStatus();
+  const isPremium = billingStatus?.isPremium ?? false;
+
+  const toggleMutation = useToggleRecurringTransactionPaused();
+  const deleteMutation = useDeleteRecurringTransaction();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] =
+    useState<RecurringTransactionWithRelations | null>(null);
+  const [templateToDelete, setTemplateToDelete] =
+    useState<RecurringTransactionWithRelations | null>(null);
+  const [upgradeReason, setUpgradeReason] = useState<string | null>(null);
+
+  usePageLoading(isLoading, "Loading recurring transactions...");
+
+  if (!recurringEnabled) {
+    return <FeatureDisabledState moduleLabel="Recurring transactions" />;
+  }
+
+  if (isLoading) {
+    return null;
+  }
+
+  const requirePremium = (action: () => void) => {
+    if (!isPremium) {
+      setUpgradeReason(RECURRING_UPGRADE_REASON);
+      return;
+    }
+    action();
+  };
+
+  const handleTogglePaused = (template: RecurringTransactionWithRelations) => {
+    requirePremium(() => {
+      toggleMutation.mutate(
+        { id: template.id, paused: !template.paused },
+        {
+          onSuccess: () =>
+            toast.success(template.paused ? "Resumed" : "Paused"),
+          onError: (error: unknown) => {
+            if (error instanceof UpgradeRequiredError) {
+              setUpgradeReason(error.message);
+              return;
+            }
+            toast.error("Failed to update recurring transaction.");
+          },
+        },
+      );
+    });
+  };
+
+  const handleEdit = (template: RecurringTransactionWithRelations) => {
+    requirePremium(() => setEditingTemplate(template));
+  };
+
+  const handleDelete = (template: RecurringTransactionWithRelations) => {
+    requirePremium(() => setTemplateToDelete(template));
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!templateToDelete) return;
+    try {
+      await deleteMutation.mutateAsync(templateToDelete.id);
+      toast.success("Recurring transaction deleted.");
+      setTemplateToDelete(null);
+    } catch (error) {
+      if (error instanceof UpgradeRequiredError) {
+        setTemplateToDelete(null);
+        setUpgradeReason(error.message);
+        return;
+      }
+      toast.error("Failed to delete recurring transaction.");
+    }
+  };
+
+  return (
+    <div className="flex flex-col bg-surface lg:h-screen">
+      <PageHeader
+        title="Recurring transactions"
+        description="Rent, subscriptions, and paychecks that post automatically"
+        action={{
+          label: "New recurring",
+          onClick: () => requirePremium(() => setShowForm(true)),
+          icon: <Plus className="h-4 w-4" />,
+        }}
+      />
+
+      <TransactionsPageNavigation />
+
+      <div className="pt-4 lg:flex-1 lg:overflow-hidden lg:pt-0">
+        <div className="lg:h-full lg:overflow-y-auto">
+          <div className="mx-auto w-full px-2 py-4 pb-28 sm:px-4 sm:py-6 sm:pb-28 lg:px-8 lg:py-4 lg:pb-8">
+            {!isPremium && (
+              <div className="card-surface mb-4 flex items-center gap-3 p-4 sm:mb-6">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-secondary/15 text-secondary-700">
+                  <Lock className="h-4 w-4" />
+                </div>
+                <p className="text-sm text-gray-600">
+                  Recurring transactions are Premium. You can view any templates
+                  below, but creating, editing, or pausing one requires
+                  upgrading.
+                </p>
+              </div>
+            )}
+
+            <div className="card-surface overflow-hidden">
+              {templates.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 px-3 py-12 text-center sm:px-6">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-full bg-surface-muted text-gray-400">
+                    <Repeat className="h-7 w-7" strokeWidth={1.5} />
+                  </div>
+                  <h3 className="text-lg font-semibold tracking-tight text-gray-900">
+                    No recurring transactions yet
+                  </h3>
+                  <p className="text-sm text-gray-500">
+                    Automate rent, subscriptions, and paychecks so you never
+                    have to enter them by hand.
+                  </p>
+                  <Button
+                    onClick={() => requirePremium(() => setShowForm(true))}
+                    variant="primary"
+                    size="md"
+                    className="mt-1"
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    New recurring transaction
+                  </Button>
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-100">
+                  {templates.map((template) => (
+                    <div
+                      key={template.id}
+                      className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium text-gray-900">
+                            {template.name ?? "Unnamed recurring transaction"}
+                          </span>
+                          <span
+                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                              template.category
+                                ? getCategoryBadgeColor(template.category.group)
+                                : getCategoryBadgeColor()
+                            }`}
+                          >
+                            {template.category?.name ?? "No category"}
+                          </span>
+                          <span className="inline-flex items-center rounded-full bg-surface-muted px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                            {FREQUENCY_LABELS[template.frequency]}
+                          </span>
+                          {template.paused && (
+                            <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                              Paused
+                            </span>
+                          )}
+                          {template.needsBudget && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
+                              <AlertTriangle className="h-3 w-3" />
+                              Needs a budget
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          {template.upcomingOccurrences.length > 0 ? (
+                            <>
+                              Next:{" "}
+                              {template.upcomingOccurrences
+                                .map(formatOccurrenceDate)
+                                .join(" · ")}
+                            </>
+                          ) : (
+                            "No upcoming occurrences"
+                          )}
+                          {template.endAt &&
+                            ` · Ends ${formatOccurrenceDate(template.endAt)}`}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center justify-between gap-3 sm:justify-end">
+                        <span className="text-sm font-semibold tabular-nums text-gray-900">
+                          {formatCurrency(Math.abs(template.amount))}
+                        </span>
+                        <div className="flex items-center gap-0.5">
+                          <button
+                            onClick={() => handleTogglePaused(template)}
+                            disabled={toggleMutation.isPending}
+                            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900 disabled:opacity-50"
+                            title={template.paused ? "Resume" : "Pause"}
+                            aria-label={
+                              template.paused
+                                ? "Resume recurring transaction"
+                                : "Pause recurring transaction"
+                            }
+                          >
+                            {template.paused ? (
+                              <Play className="h-4 w-4" />
+                            ) : (
+                              <Pause className="h-4 w-4" />
+                            )}
+                          </button>
+                          <button
+                            onClick={() => handleEdit(template)}
+                            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900"
+                            title="Edit"
+                            aria-label="Edit recurring transaction"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(template)}
+                            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors duration-200 hover:bg-red-50 hover:text-red-600"
+                            title="Delete"
+                            aria-label="Delete recurring transaction"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <RecurringTransactionForm
+        isOpen={showForm}
+        onClose={() => setShowForm(false)}
+      />
+
+      <RecurringTransactionForm
+        isOpen={!!editingTemplate}
+        template={editingTemplate ?? undefined}
+        onClose={() => setEditingTemplate(null)}
+      />
+
+      <DeleteConfirmationModal
+        isOpen={!!templateToDelete}
+        onClose={() => setTemplateToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        title="Delete recurring transaction"
+        message="Are you sure you want to delete '{itemName}'? Past posted transactions are kept; future occurrences will stop. This action cannot be undone."
+        itemName={templateToDelete?.name ?? "Unnamed recurring transaction"}
+        isLoading={deleteMutation.isPending}
+        loadingText="Deleting..."
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
+
+      <UpgradeModal
+        isOpen={upgradeReason !== null}
+        onClose={() => setUpgradeReason(null)}
+        reason={upgradeReason ?? undefined}
+      />
+    </div>
+  );
+}

--- a/src/env.js
+++ b/src/env.js
@@ -38,6 +38,14 @@ export const env = createEnv({
     // src/server/email.ts for dev-mode fallback behavior when unset.
     RESEND_API_KEY: z.string().optional(),
     EMAIL_FROM: z.string().optional(),
+    // Shared secret verified against the cron job's `Authorization: Bearer`
+    // header (see src/app/api/cron/recurring/route.ts). Vercel Cron
+    // automatically sends this header when an env var named exactly
+    // CRON_SECRET is set, so no extra config is needed there.
+    CRON_SECRET:
+      process.env.NODE_ENV === "production"
+        ? z.string()
+        : z.string().optional(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -72,6 +80,7 @@ export const env = createEnv({
     STRIPE_PRICE_ANNUAL_ID: process.env.STRIPE_PRICE_ANNUAL_ID,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     EMAIL_FROM: process.env.EMAIL_FROM,
+    CRON_SECRET: process.env.CRON_SECRET,
     NODE_ENV: process.env.NODE_ENV,
   },
   /**

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/recurring",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Feature 2 — Recurring transactions (PREMIUM, view-only on free)

Stacked on #93 (Feature 1). Auto-posts repeating transactions (rent, subscriptions, paychecks) each period.

### What's included
- **Schema**: `RecurringTransaction` model (template mirroring `Transaction` + `frequency` (`PeriodType`), `nextRunAt`, `endAt?`, `paused`, soft-delete) and `Transaction.recurringTransactionId` back-reference. Migration `add_recurring_transactions` (additive: new table + column, no drops).
- **Posting engine** (pure): `lib/utils/recurring.ts` — `addPeriod`, `computeDueOccurrences` (idempotent catch-up over missed periods, `endAt` capping, `ONE_TIME`), `previewUpcomingOccurrences`, `findBudgetForOccurrence`. 24 unit tests.
- **Idempotency**: stored `nextRunAt` pointer is the guard; DB layer also checks `(recurringTransactionId, occurredAt)` behind a unique index and advances the pointer after each post, so a mid-loop crash can't double-post.
- **Budget-boundary rule**: each occurrence resolves the active budget covering its date; if none, it holds (`nextRunAt` parks on that date, surfaced as `needsBudget`) rather than dropping.
- **Entitlement**: `canCreateRecurring` (free: 0 → premium-only) in `lib/utils/entitlements.ts` (+ tests); create/update/delete gated via `paymentRequired`; free users keep read-only list access. Auto-posting no-ops for non-premium accounts.
- **Cron + lazy catch-up**: `/api/cron/recurring` (Bearer `CRON_SECRET`), `vercel.json` daily schedule, plus an on-session lazy catch-up (`useRecurringCatchUp` in `ConditionalLayout`) so dev/self-host works without cron.
- **Feature toggle**: `recurringTransactions` added to `TOGGLEABLE_MODULES`; management page `/transactions/recurring` respects the toggle + premium gate.
- **UI**: management list w/ upcoming-occurrences preview + pause/resume, "make recurring" on the transaction form, `Repeat` badge on auto-posted transactions.

### Notes for review
- The whole `prisma/schema.prisma` was reflowed by `prisma format` (4-space → 2-space). Cosmetic; the semantic change is the new model + back-references. Kept consistent for the rest of the stack.
- `migrate dev` needs a TTY in the agent env, so the migration was authored via `migrate diff` + applied via `migrate deploy`. `prisma migrate status` reports the DB up to date.

`pnpm check` clean; 102/102 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)