### PR TITLE
Feature 4: CSV import/export (export free, import premium)

### DIFF
--- a/components/transactions/ImportTransactionsModal.tsx
+++ b/components/transactions/ImportTransactionsModal.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { AlertTriangle, ArrowLeft, FileUp, Upload } from "lucide-react";
+import { toast } from "react-hot-toast";
+import Modal from "../Modal";
+import Button from "../Button";
+import UpgradeModal from "../UpgradeModal";
+import { useActiveBudgets } from "@/lib/data-hooks/budgets/useBudgets";
+import {
+  useImportTransactions,
+  useImportTransactionsPreview,
+} from "@/lib/data-hooks/transactions/useTransactions";
+import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
+import { parseCsv } from "@/lib/utils/csv";
+import {
+  REQUIRED_IMPORT_COLUMNS,
+  type ImportColumnKey,
+  type ImportPreviewRow,
+  type RawImportRow,
+} from "@/lib/utils/transaction-import";
+import { formatCurrency } from "@/lib/utils";
+
+interface ImportTransactionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** True when the account may import (premium). Free users see a paywall. */
+  canImport: boolean;
+}
+
+type Step = "upload" | "map" | "preview";
+
+// Human labels for each mappable column and whether it's required.
+const COLUMN_META: {
+  key: ImportColumnKey;
+  label: string;
+  required: boolean;
+}[] = [
+  { key: "date", label: "Date", required: true },
+  { key: "amount", label: "Amount", required: true },
+  { key: "name", label: "Name / description", required: false },
+  { key: "category", label: "Category", required: false },
+  { key: "card", label: "Card", required: false },
+  { key: "type", label: "Type", required: false },
+];
+
+// Header-name patterns used to pre-fill the column mapping from the CSV.
+const GUESS_PATTERNS: Record<ImportColumnKey, RegExp> = {
+  date: /date|posted|time/i,
+  amount: /amount|value|total|debit|credit|price/i,
+  name: /name|description|payee|memo|merchant|detail/i,
+  category: /category|group/i,
+  card: /card|account/i,
+  type: /type|kind/i,
+};
+
+type Mapping = Record<ImportColumnKey, number | null>;
+
+const emptyMapping = (): Mapping => ({
+  date: null,
+  name: null,
+  amount: null,
+  category: null,
+  card: null,
+  type: null,
+});
+
+const guessMapping = (headers: string[]): Mapping => {
+  const mapping = emptyMapping();
+  (Object.keys(GUESS_PATTERNS) as ImportColumnKey[]).forEach((key) => {
+    const idx = headers.findIndex((h) => GUESS_PATTERNS[key].test(h));
+    if (idx >= 0) mapping[key] = idx;
+  });
+  return mapping;
+};
+
+export default function ImportTransactionsModal({
+  isOpen,
+  onClose,
+  canImport,
+}: ImportTransactionsModalProps) {
+  const { data: budgets = [] } = useActiveBudgets();
+  const previewMutation = useImportTransactionsPreview();
+  const commitMutation = useImportTransactions();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [step, setStep] = useState<Step>("upload");
+  const [fileName, setFileName] = useState("");
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [dataRows, setDataRows] = useState<string[][]>([]);
+  const [mapping, setMapping] = useState<Mapping>(emptyMapping());
+  const [selectedBudgetId, setSelectedBudgetId] = useState("");
+  const [preview, setPreview] = useState<ImportPreviewRow[]>([]);
+  const [excluded, setExcluded] = useState<Set<number>>(new Set());
+  const [upgradeReason, setUpgradeReason] = useState<string | null>(null);
+
+  const reset = () => {
+    setStep("upload");
+    setFileName("");
+    setHeaders([]);
+    setDataRows([]);
+    setMapping(emptyMapping());
+    setPreview([]);
+    setExcluded(new Set());
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  // Build the mapped raw rows from the CSV data using the current mapping.
+  const buildRawRows = (): RawImportRow[] => {
+    const cell = (row: string[], key: ImportColumnKey): string => {
+      const idx = mapping[key];
+      return idx != null ? (row[idx] ?? "") : "";
+    };
+    return dataRows.map((row) => ({
+      date: cell(row, "date"),
+      name: cell(row, "name"),
+      amount: cell(row, "amount"),
+      category: cell(row, "category"),
+      card: cell(row, "card"),
+      type: cell(row, "type"),
+    }));
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const { headers: parsedHeaders, rows } = parseCsv(text);
+      if (parsedHeaders.length === 0 || rows.length === 0) {
+        toast.error("That file has no data rows to import.");
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        return;
+      }
+      setFileName(file.name);
+      setHeaders(parsedHeaders);
+      setDataRows(rows);
+      setMapping(guessMapping(parsedHeaders));
+      setStep("map");
+    } catch (err) {
+      console.error("Failed to read CSV:", err);
+      toast.error("Could not read that file. Make sure it's a CSV.");
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const missingRequired = REQUIRED_IMPORT_COLUMNS.filter(
+    (key) => mapping[key] === null,
+  );
+
+  const handlePreview = () => {
+    if (!selectedBudgetId) {
+      toast.error("Select a budget to import into.");
+      return;
+    }
+    if (missingRequired.length > 0) {
+      toast.error("Map the date and amount columns first.");
+      return;
+    }
+
+    previewMutation.mutate(
+      { budgetId: selectedBudgetId, rows: buildRawRows() },
+      {
+        onSuccess: (data) => {
+          setPreview(data.preview);
+          // Default: exclude invalid rows (can't import) and duplicates
+          // (avoid re-importing) — the user can re-include duplicates.
+          const initialExcluded = new Set<number>();
+          data.preview.forEach((r) => {
+            if (!r.valid || r.duplicate) initialExcluded.add(r.index);
+          });
+          setExcluded(initialExcluded);
+          setStep("preview");
+        },
+        onError: (error: unknown) => {
+          if (error instanceof UpgradeRequiredError) {
+            setUpgradeReason(error.message);
+            return;
+          }
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Could not preview the import.",
+          );
+        },
+      },
+    );
+  };
+
+  const toggleRow = (index: number) => {
+    setExcluded((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const includedCount = useMemo(
+    () => preview.filter((r) => r.valid && !excluded.has(r.index)).length,
+    [preview, excluded],
+  );
+
+  const handleCommit = () => {
+    const rawRows = buildRawRows();
+    const rowsToImport = preview
+      .filter((r) => r.valid && !excluded.has(r.index))
+      .map((r) => rawRows[r.index]!)
+      .filter(Boolean);
+
+    if (rowsToImport.length === 0) {
+      toast.error("Select at least one row to import.");
+      return;
+    }
+
+    commitMutation.mutate(
+      { budgetId: selectedBudgetId, rows: rowsToImport },
+      {
+        onSuccess: (data) => {
+          toast.success(
+            `Imported ${data.imported} transaction${
+              data.imported === 1 ? "" : "s"
+            }.`,
+          );
+          handleClose();
+        },
+        onError: (error: unknown) => {
+          if (error instanceof UpgradeRequiredError) {
+            setUpgradeReason(error.message);
+            return;
+          }
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Could not import the transactions.",
+          );
+        },
+      },
+    );
+  };
+
+  // Free users: show the paywall directly instead of the import flow.
+  if (isOpen && !canImport) {
+    return (
+      <UpgradeModal
+        isOpen={isOpen}
+        onClose={handleClose}
+        reason="Importing transactions from a CSV is a Premium feature. Upgrade to Premium to import your data."
+      />
+    );
+  }
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen && upgradeReason === null}
+        onClose={handleClose}
+        title="Import transactions"
+        maxWidth="max-w-3xl"
+      >
+        {step === "upload" && (
+          <div className="space-y-5">
+            <p className="text-sm text-gray-500">
+              Upload a CSV exported from your bank, Mint, or YNAB. You&apos;ll
+              map the columns and review every row before anything is saved.
+            </p>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              onChange={handleFile}
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex w-full flex-col items-center gap-3 rounded-xl border-2 border-dashed border-gray-300 py-12 text-center transition-colors duration-200 hover:border-secondary hover:bg-surface"
+            >
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-surface-muted text-secondary-600">
+                <FileUp className="h-7 w-7" strokeWidth={1.5} />
+              </div>
+              <span className="text-sm font-semibold text-gray-900">
+                Choose a CSV file
+              </span>
+              <span className="text-xs text-gray-500">
+                We&apos;ll never store your file — it&apos;s parsed in your
+                browser.
+              </span>
+            </button>
+          </div>
+        )}
+
+        {step === "map" && (
+          <div className="space-y-5">
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <FileUp className="h-4 w-4 shrink-0" />
+              <span className="truncate">{fileName}</span>
+              <span className="shrink-0 text-gray-400">
+                · {dataRows.length} row{dataRows.length === 1 ? "" : "s"}
+              </span>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Import into budget <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={selectedBudgetId}
+                onChange={(e) => setSelectedBudgetId(e.target.value)}
+                className="w-full rounded-xl border border-gray-300 bg-surface-card px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+              >
+                <option value="">Select an active budget</option>
+                {budgets.map((budget) => (
+                  <option key={budget.id} value={budget.id}>
+                    {budget.name}
+                  </option>
+                ))}
+              </select>
+              {budgets.length === 0 && (
+                <p className="mt-1 text-xs text-amber-700">
+                  You need an active budget before importing.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-gray-900">
+                Map your columns
+              </p>
+              {COLUMN_META.map(({ key, label, required }) => (
+                <div
+                  key={key}
+                  className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+                >
+                  <span className="text-sm text-gray-700">
+                    {label}
+                    {required && <span className="text-red-500"> *</span>}
+                  </span>
+                  <select
+                    value={mapping[key] ?? ""}
+                    onChange={(e) =>
+                      setMapping((prev) => ({
+                        ...prev,
+                        [key]:
+                          e.target.value === "" ? null : Number(e.target.value),
+                      }))
+                    }
+                    className="w-full rounded-xl border border-gray-300 bg-surface-card px-3 py-2 text-sm focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary sm:w-64"
+                  >
+                    <option value="">
+                      {required ? "Select a column" : "Not mapped"}
+                    </option>
+                    {headers.map((header, idx) => (
+                      <option key={idx} value={idx}>
+                        {header || `Column ${idx + 1}`}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+              <Button variant="ghost" onClick={reset}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Choose another file
+              </Button>
+              <Button
+                onClick={handlePreview}
+                isLoading={previewMutation.isPending}
+                disabled={
+                  !selectedBudgetId ||
+                  missingRequired.length > 0 ||
+                  previewMutation.isPending
+                }
+              >
+                Preview import
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === "preview" && (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="rounded-full bg-green-50 px-2.5 py-0.5 font-medium text-green-700">
+                {includedCount} to import
+              </span>
+              {preview.some((r) => r.duplicate) && (
+                <span className="rounded-full bg-amber-50 px-2.5 py-0.5 font-medium text-amber-700">
+                  {preview.filter((r) => r.duplicate).length} possible duplicate
+                  {preview.filter((r) => r.duplicate).length === 1 ? "" : "s"}
+                </span>
+              )}
+              {preview.some((r) => !r.valid) && (
+                <span className="rounded-full bg-red-50 px-2.5 py-0.5 font-medium text-red-700">
+                  {preview.filter((r) => !r.valid).length} can&apos;t import
+                </span>
+              )}
+            </div>
+
+            <div className="max-h-[50vh] overflow-y-auto overscroll-contain rounded-xl border border-gray-200/70">
+              <div className="divide-y divide-gray-100">
+                {preview.map((row) => {
+                  const isIncluded = row.valid && !excluded.has(row.index);
+                  return (
+                    <div
+                      key={row.index}
+                      className={`flex items-start gap-3 p-3 ${
+                        row.valid ? "" : "bg-red-50/50"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isIncluded}
+                        disabled={!row.valid}
+                        onChange={() => toggleRow(row.index)}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 text-secondary-600 focus:ring-secondary disabled:opacity-40"
+                        aria-label={`Include row ${row.index + 1}`}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium text-gray-900">
+                            {row.name || "Unnamed transaction"}
+                          </span>
+                          {row.duplicate && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                              <AlertTriangle className="h-3 w-3" />
+                              Duplicate
+                            </span>
+                          )}
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                              row.matchedCategoryId
+                                ? "bg-secondary/15 text-secondary-800"
+                                : "bg-gray-100 text-gray-600"
+                            }`}
+                          >
+                            {row.matchedCategoryName ??
+                              (row.categoryName
+                                ? `${row.categoryName} (uncategorized)`
+                                : "Uncategorized")}
+                          </span>
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-gray-500">
+                          <span>{row.occurredAt ?? (row.rawDate || "—")}</span>
+                          <span className="capitalize">
+                            {row.transactionType
+                              .toLowerCase()
+                              .replace("_", " ")}
+                          </span>
+                        </div>
+                        {row.errors.length > 0 && (
+                          <p className="mt-1 text-xs text-red-600">
+                            {row.errors.join(", ")}
+                          </p>
+                        )}
+                      </div>
+                      <div className="shrink-0 text-right text-sm font-semibold tabular-nums text-gray-900">
+                        {row.amount !== null
+                          ? formatCurrency(Math.abs(row.amount))
+                          : "—"}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+              <Button variant="ghost" onClick={() => setStep("map")}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to mapping
+              </Button>
+              <Button
+                onClick={handleCommit}
+                isLoading={commitMutation.isPending}
+                disabled={includedCount === 0 || commitMutation.isPending}
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                Import {includedCount} transaction
+                {includedCount === 1 ? "" : "s"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      <UpgradeModal
+        isOpen={upgradeReason !== null}
+        onClose={() => {
+          setUpgradeReason(null);
+          handleClose();
+        }}
+        reason={upgradeReason ?? undefined}
+      />
+    </>
+  );
+}

--- a/lib/api-schemas/transactions.ts
+++ b/lib/api-schemas/transactions.ts
@@ -145,3 +145,30 @@ export type CreateCardPaymentSchema = z.infer<typeof createCardPaymentSchema>;
 export type CreateTransactionsBatchSchema = z.infer<
   typeof createTransactionsBatchSchema
 >;
+
+// A single mapped CSV row sent to the import endpoint. All values arrive as
+// raw strings; parsing/validation happens server-side via
+// `lib/utils/transaction-import.ts` (mirrored client-side for the preview).
+export const importTransactionRowSchema = z.object({
+  date: z.string().default(""),
+  name: z.string().default(""),
+  amount: z.string().default(""),
+  category: z.string().default(""),
+  card: z.string().default(""),
+  type: z.string().default(""),
+});
+
+// CSV import request: which budget the rows post into, the mapped rows, and
+// whether to actually persist (`commit`) or just return a validated preview.
+export const importTransactionsSchema = z.object({
+  budgetId: z.string().min(1, "Budget is required"),
+  rows: z
+    .array(importTransactionRowSchema)
+    .min(1, "At least one row is required"),
+  commit: z.boolean().default(false),
+});
+
+export type ImportTransactionRowSchema = z.infer<
+  typeof importTransactionRowSchema
+>;
+export type ImportTransactionsSchema = z.infer<typeof importTransactionsSchema>;

--- a/lib/api-services/transactions.ts
+++ b/lib/api-services/transactions.ts
@@ -9,6 +9,13 @@ import type {
 import type { PrismaClientTx } from "../prisma";
 import { HttpError } from "../errors";
 import { roundToCents } from "../utils";
+import { toIsoDateString } from "../utils/csv";
+import {
+  duplicateKey,
+  normalizeName,
+  type ImportRowContext,
+  type NamedRef,
+} from "../utils/transaction-import";
 
 // Every transaction we return includes its splits + each split's category
 // (with its default category), so callers never need a second fetch to
@@ -114,6 +121,133 @@ export const getTransactions = async (
     });
     return { transactions, totalCount: transactions.length };
   }
+};
+
+// Columns emitted by the CSV export, in order. Kept here (not in the route)
+// so the shape is unit-testable and the header/row builders stay aligned.
+export const EXPORT_COLUMNS = [
+  "Date",
+  "Name",
+  "Description",
+  "Amount",
+  "Type",
+  "Category",
+  "Card",
+  "Budget",
+] as const;
+
+/**
+ * Returns every (non-deleted) transaction for the account as ordered CSV
+ * field arrays plus the header row, ready to hand to `buildCsv`. Category and
+ * card NAMES are emitted (never ids); split transactions list their split
+ * categories joined by "; ". Dates are the ISO date of `occurredAt`
+ * (falling back to `createdAt`).
+ */
+export const getTransactionsForExport = async (
+  tx: PrismaClientTx,
+  accountId: string,
+): Promise<{ headers: string[]; rows: (string | number)[][] }> => {
+  const transactions = await tx.transaction.findMany({
+    where: { accountId, deleted: null },
+    include: {
+      category: { select: { name: true } },
+      card: { select: { name: true } },
+      Budget: { select: { name: true } },
+      splits: { include: { category: { select: { name: true } } } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const rows = transactions.map((t): (string | number)[] => {
+    const categoryLabel =
+      t.splits.length > 0
+        ? t.splits.map((s) => s.category.name).join("; ")
+        : (t.category?.name ?? "");
+
+    return [
+      toIsoDateString(t.occurredAt ?? t.createdAt),
+      t.name ?? "",
+      t.description ?? "",
+      t.amount,
+      t.transactionType,
+      categoryLabel,
+      t.card?.name ?? "",
+      t.Budget?.name ?? "",
+    ];
+  });
+
+  return { headers: [...EXPORT_COLUMNS], rows };
+};
+
+/**
+ * Loads everything the import preview/commit needs for a given budget:
+ * validates the budget belongs to the account (and is ACTIVE), then builds
+ * the case-insensitive category/card lookups and the set of existing
+ * (date+amount+name) keys used for duplicate detection.
+ */
+export const getImportContext = async (
+  tx: PrismaClientTx,
+  accountId: string,
+  budgetId: string,
+): Promise<{ budgetName: string; context: ImportRowContext }> => {
+  const budget = await tx.budget.findFirst({
+    where: { id: budgetId, accountId, deleted: null },
+    select: { id: true, name: true, status: true },
+  });
+
+  if (!budget) {
+    throw new HttpError("Budget not found", 404);
+  }
+  if (budget.status !== "ACTIVE") {
+    throw new HttpError(
+      "Transactions can only be imported into an active budget",
+      400,
+    );
+  }
+
+  const [categories, cards, existing] = await Promise.all([
+    tx.category.findMany({
+      where: { budgetId, deleted: null },
+      select: { id: true, name: true },
+    }),
+    tx.card.findMany({
+      where: { budgetId, deleted: null },
+      select: { id: true, name: true },
+    }),
+    tx.transaction.findMany({
+      where: { accountId, deleted: null },
+      select: {
+        name: true,
+        amount: true,
+        occurredAt: true,
+        createdAt: true,
+      },
+    }),
+  ]);
+
+  const categoriesByName = new Map<string, NamedRef>();
+  for (const c of categories) {
+    // First match wins so a budget's own category name is stable.
+    const key = normalizeName(c.name);
+    if (!categoriesByName.has(key)) categoriesByName.set(key, c);
+  }
+
+  const cardsByName = new Map<string, NamedRef>();
+  for (const c of cards) {
+    const key = normalizeName(c.name);
+    if (!cardsByName.has(key)) cardsByName.set(key, c);
+  }
+
+  const existingKeys = new Set<string>();
+  for (const t of existing) {
+    const iso = toIsoDateString(t.occurredAt ?? t.createdAt);
+    if (iso) existingKeys.add(duplicateKey(iso, t.amount, t.name ?? ""));
+  }
+
+  return {
+    budgetName: budget.name,
+    context: { categoriesByName, cardsByName, existingKeys },
+  };
 };
 
 export const createTransaction = async (

--- a/lib/data-hooks/services/transactions.ts
+++ b/lib/data-hooks/services/transactions.ts
@@ -4,6 +4,21 @@ import type {
   TransactionWithRelations,
 } from "@/lib/types/transaction";
 import type { CreateCardPaymentSchema } from "@/lib/api-schemas/transactions";
+import type {
+  ImportPreviewRow,
+  RawImportRow,
+} from "@/lib/utils/transaction-import";
+import { parseErrorResponse } from "./http";
+
+export interface ImportPreviewResponse {
+  budgetName: string;
+  preview: ImportPreviewRow[];
+}
+
+export interface ImportCommitResponse {
+  imported: number;
+  skipped: number;
+}
 
 interface CardPaymentResponse {
   message: string;
@@ -155,4 +170,59 @@ export const createCardPayment = async (
   }
 
   return result.result;
+};
+
+// Fetches the account's transactions as a CSV and triggers a browser
+// download. Export is free (no paywall), so no UpgradeRequiredError handling.
+export const exportTransactionsCsv = async (): Promise<void> => {
+  const response = await fetch("/api/transactions/export");
+  if (!response.ok) return parseErrorResponse(response);
+
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") ?? "";
+  const match = /filename="?([^";]+)"?/.exec(disposition);
+  const filename = match?.[1] ?? "ronin-transactions.csv";
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+// Preview (dry-run) the import: server validates rows, matches categories,
+// and flags duplicates without persisting anything. Throws
+// UpgradeRequiredError on the 402 paywall so the modal can open UpgradeModal.
+export const previewImportTransactions = async (
+  budgetId: string,
+  rows: RawImportRow[],
+): Promise<ImportPreviewResponse> => {
+  const response = await fetch("/api/transactions/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ budgetId, rows, commit: false }),
+  });
+
+  if (!response.ok) return parseErrorResponse(response);
+
+  return response.json() as Promise<ImportPreviewResponse>;
+};
+
+// Commit the import: persist the valid rows via the shared batch path.
+export const commitImportTransactions = async (
+  budgetId: string,
+  rows: RawImportRow[],
+): Promise<ImportCommitResponse> => {
+  const response = await fetch("/api/transactions/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ budgetId, rows, commit: true }),
+  });
+
+  if (!response.ok) return parseErrorResponse(response);
+
+  return response.json() as Promise<ImportCommitResponse>;
 };

--- a/lib/data-hooks/transactions/useTransactions.ts
+++ b/lib/data-hooks/transactions/useTransactions.ts
@@ -12,6 +12,8 @@ import {
   updateTransaction,
   deleteTransaction,
   createCardPayment,
+  previewImportTransactions,
+  commitImportTransactions,
 } from "../services/transactions";
 import type {
   CreateTransactionRequest,
@@ -19,6 +21,7 @@ import type {
   TransactionWithRelations,
 } from "@/lib/types/transaction";
 import type { CreateCardPaymentSchema } from "@/lib/api-schemas/transactions";
+import type { RawImportRow } from "@/lib/utils/transaction-import";
 
 export const useTransactions = (page = 1, limit = 20) => {
   const { data: session } = useSession();
@@ -134,6 +137,51 @@ export const useCreateTransactionsBatch = () => {
         });
         void queryClient.invalidateQueries({ queryKey: ["cards", cardId] });
       });
+    },
+  });
+};
+
+// Dry-run: validate/annotate mapped CSV rows without persisting. Read-only,
+// so no cache invalidation.
+export const useImportTransactionsPreview = () => {
+  return useMutation({
+    mutationFn: ({
+      budgetId,
+      rows,
+    }: {
+      budgetId: string;
+      rows: RawImportRow[];
+    }) => previewImportTransactions(budgetId, rows),
+  });
+};
+
+// Commit an import into a budget; invalidates the same keys the batch-create
+// hook does so the transactions list, budget, and card views all refresh.
+export const useImportTransactions = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      budgetId,
+      rows,
+    }: {
+      budgetId: string;
+      rows: RawImportRow[];
+    }) => commitImportTransactions(budgetId, rows),
+    onSuccess: (_, { budgetId }) => {
+      void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      void queryClient.invalidateQueries({ queryKey: ["allTransactions"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["budgetTransactions", budgetId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ["budget", budgetId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["budgetCategories", budgetId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["budgetCards", budgetId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ["cards"] });
     },
   });
 };

--- a/lib/utils/csv.test.ts
+++ b/lib/utils/csv.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCsv,
+  buildCsvRow,
+  escapeCsvField,
+  parseCsv,
+  toIsoDateString,
+} from "@/lib/utils/csv";
+
+describe("escapeCsvField", () => {
+  it("returns simple values unquoted", () => {
+    expect(escapeCsvField("Groceries")).toBe("Groceries");
+    expect(escapeCsvField(42)).toBe("42");
+  });
+
+  it("renders null/undefined as an empty field", () => {
+    expect(escapeCsvField(null)).toBe("");
+    expect(escapeCsvField(undefined)).toBe("");
+  });
+
+  it("quotes fields containing a comma", () => {
+    expect(escapeCsvField("Rent, utilities")).toBe('"Rent, utilities"');
+  });
+
+  it("quotes fields containing a double quote and doubles it", () => {
+    expect(escapeCsvField('The "big" sale')).toBe('"The ""big"" sale"');
+  });
+
+  it("quotes fields containing a newline", () => {
+    expect(escapeCsvField("line one\nline two")).toBe('"line one\nline two"');
+  });
+
+  it("quotes fields containing a carriage return", () => {
+    expect(escapeCsvField("line one\r\nline two")).toBe(
+      '"line one\r\nline two"',
+    );
+  });
+});
+
+describe("buildCsvRow", () => {
+  it("joins escaped fields with commas", () => {
+    expect(buildCsvRow(["2024-01-15", "Rent, base", 1200, null])).toBe(
+      '2024-01-15,"Rent, base",1200,',
+    );
+  });
+});
+
+describe("buildCsv", () => {
+  it("builds a header row plus data rows with CRLF endings", () => {
+    const csv = buildCsv(
+      ["Date", "Name", "Amount"],
+      [
+        ["2024-01-01", "Coffee", 4.5],
+        ["2024-01-02", "Rent, deposit", 1000],
+      ],
+    );
+
+    expect(csv).toBe(
+      'Date,Name,Amount\r\n2024-01-01,Coffee,4.5\r\n2024-01-02,"Rent, deposit",1000\r\n',
+    );
+  });
+
+  it("produces an empty CSV (just the header) for zero rows", () => {
+    expect(buildCsv(["Date", "Name"], [])).toBe("Date,Name\r\n");
+  });
+});
+
+describe("toIsoDateString", () => {
+  it("formats a Date object as YYYY-MM-DD", () => {
+    expect(toIsoDateString(new Date(Date.UTC(2024, 2, 5)))).toBe("2024-03-05");
+  });
+
+  it("formats an ISO datetime string as its date portion", () => {
+    expect(toIsoDateString("2024-03-05T18:30:00.000Z")).toBe("2024-03-05");
+  });
+
+  it("returns an empty string for null/undefined/invalid input", () => {
+    expect(toIsoDateString(null)).toBe("");
+    expect(toIsoDateString(undefined)).toBe("");
+    expect(toIsoDateString("not a date")).toBe("");
+  });
+});
+
+describe("parseCsv", () => {
+  it("parses a simple CSV with a header and data rows", () => {
+    const { headers, rows } = parseCsv(
+      "Date,Name,Amount\n2024-01-01,Coffee,4.50\n2024-01-02,Lunch,12.00\n",
+    );
+    expect(headers).toEqual(["Date", "Name", "Amount"]);
+    expect(rows).toEqual([
+      ["2024-01-01", "Coffee", "4.50"],
+      ["2024-01-02", "Lunch", "12.00"],
+    ]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const { headers, rows } = parseCsv(
+      "Date,Name\r\n2024-01-01,Coffee\r\n2024-01-02,Lunch\r\n",
+    );
+    expect(headers).toEqual(["Date", "Name"]);
+    expect(rows).toEqual([
+      ["2024-01-01", "Coffee"],
+      ["2024-01-02", "Lunch"],
+    ]);
+  });
+
+  it("parses quoted fields containing embedded commas", () => {
+    const { rows } = parseCsv(
+      'Date,Name,Amount\n2024-01-01,"Rent, base",1200\n',
+    );
+    expect(rows).toEqual([["2024-01-01", "Rent, base", "1200"]]);
+  });
+
+  it("parses quoted fields containing embedded newlines", () => {
+    const { rows } = parseCsv('Date,Notes\n2024-01-01,"line one\nline two"\n');
+    expect(rows).toEqual([["2024-01-01", "line one\nline two"]]);
+  });
+
+  it("unescapes doubled quotes inside a quoted field", () => {
+    const { rows } = parseCsv('Date,Name\n2024-01-01,"The ""big"" sale"\n');
+    expect(rows).toEqual([["2024-01-01", 'The "big" sale']]);
+  });
+
+  it("ignores a trailing blank line", () => {
+    const { headers, rows } = parseCsv("Date,Name\n2024-01-01,Coffee\n\n");
+    expect(headers).toEqual(["Date", "Name"]);
+    expect(rows).toEqual([["2024-01-01", "Coffee"]]);
+  });
+
+  it("handles a file with no trailing newline", () => {
+    const { headers, rows } = parseCsv("Date,Name\n2024-01-01,Coffee");
+    expect(headers).toEqual(["Date", "Name"]);
+    expect(rows).toEqual([["2024-01-01", "Coffee"]]);
+  });
+
+  it("returns empty headers/rows for an empty string", () => {
+    expect(parseCsv("")).toEqual({ headers: [], rows: [] });
+  });
+
+  it("handles a header-only CSV (no data rows)", () => {
+    expect(parseCsv("Date,Name,Amount\n")).toEqual({
+      headers: ["Date", "Name", "Amount"],
+      rows: [],
+    });
+  });
+
+  it("preserves empty fields within a row", () => {
+    const { rows } = parseCsv("Date,Name,Amount\n2024-01-01,,4.50\n");
+    expect(rows).toEqual([["2024-01-01", "", "4.50"]]);
+  });
+});

--- a/lib/utils/csv.ts
+++ b/lib/utils/csv.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure CSV parsing/formatting helpers shared by the transactions export
+ * (`src/app/api/transactions/export/route.ts`) and import
+ * (`src/app/api/transactions/import/route.ts`,
+ * `components/transactions/ImportTransactionsModal.tsx`) flows. Kept
+ * dependency-free and side-effect-free so it's cheap to unit test and safe
+ * to run on both the server and the client.
+ */
+
+/** A single CSV field value. `null`/`undefined` render as an empty field. */
+export type CsvFieldValue = string | number | null | undefined;
+
+/**
+ * Escapes a single CSV field per RFC 4180: wraps the value in double quotes
+ * whenever it contains a comma, double quote, or newline, doubling any
+ * embedded double quotes. Values with no special characters are returned
+ * unquoted — unquoted is valid CSV and keeps the common case readable.
+ */
+export function escapeCsvField(value: CsvFieldValue): string {
+  const str = value === null || value === undefined ? "" : String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/** Joins already-ordered field values into one escaped CSV row (no trailing newline). */
+export function buildCsvRow(fields: CsvFieldValue[]): string {
+  return fields.map(escapeCsvField).join(",");
+}
+
+/**
+ * Builds a full CSV document (header row + data rows) using CRLF line
+ * endings per RFC 4180, ending with a trailing CRLF after the last row.
+ */
+export function buildCsv(headers: string[], rows: CsvFieldValue[][]): string {
+  const lines = [buildCsvRow(headers), ...rows.map(buildCsvRow)];
+  return lines.join("\r\n") + "\r\n";
+}
+
+/** Formats a Date (or ISO/date string) as a `YYYY-MM-DD` date-only string. Returns "" for invalid/empty input. */
+export function toIsoDateString(
+  value: Date | string | null | undefined,
+): string {
+  if (!value) return "";
+  const date = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+export interface ParsedCsv {
+  headers: string[];
+  rows: string[][];
+}
+
+/**
+ * Hand-rolled RFC-4180-ish CSV parser: handles quoted fields, embedded
+ * commas/newlines inside quotes, escaped quotes (`""`), and both CRLF and
+ * LF line endings. The first record becomes `headers`; fully blank lines
+ * (no delimiters, empty content) are dropped so a trailing newline at the
+ * end of the file doesn't produce a phantom empty row.
+ *
+ * A small hand-rolled parser is used instead of a dependency: the format
+ * needed here (quoted fields with embedded commas/newlines, `""` escaping)
+ * is fully specified by RFC 4180 and small enough to implement and test
+ * directly, so pulling in a CSV library isn't warranted.
+ */
+export function parseCsv(text: string): ParsedCsv {
+  const records: string[][] = [];
+  let field = "";
+  let record: string[] = [];
+  let inQuotes = false;
+  let i = 0;
+  const len = text.length;
+
+  const pushField = () => {
+    record.push(field);
+    field = "";
+  };
+  const pushRecord = () => {
+    pushField();
+    records.push(record);
+    record = [];
+  };
+
+  while (i < len) {
+    const char = text[i]!;
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += char;
+      i += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === ",") {
+      pushField();
+      i += 1;
+      continue;
+    }
+
+    if (char === "\r") {
+      // Treat CRLF and lone CR as a single record break.
+      pushRecord();
+      i += text[i + 1] === "\n" ? 2 : 1;
+      continue;
+    }
+
+    if (char === "\n") {
+      pushRecord();
+      i += 1;
+      continue;
+    }
+
+    field += char;
+    i += 1;
+  }
+
+  // Flush a trailing field/record when the text doesn't end with a newline.
+  if (field.length > 0 || record.length > 0) {
+    pushRecord();
+  }
+
+  // Drop rows produced by a stray blank line (a single empty-string field) —
+  // most commonly a trailing newline at end-of-file.
+  const nonBlankRecords = records.filter(
+    (r) => !(r.length === 1 && r[0] === ""),
+  );
+
+  const [headerRow, ...dataRows] = nonBlankRecords;
+  return {
+    headers: headerRow ?? [],
+    rows: dataRows,
+  };
+}

--- a/lib/utils/entitlements.test.ts
+++ b/lib/utils/entitlements.test.ts
@@ -4,6 +4,7 @@ import {
   canCreateBudget,
   canCreatePocket,
   canCreateRecurring,
+  canImportTransactions,
   canInviteMember,
   canScanReceipt,
   canSplitTransactions,
@@ -224,6 +225,28 @@ describe("canSplitTransactions", () => {
         }),
       ).allowed,
     ).toBe(false);
+  });
+});
+
+describe("canImportTransactions", () => {
+  it("denies a FREE account with an upgrade reason", () => {
+    const result = canImportTransactions(account());
+    expect(result.allowed).toBe(false);
+    expect(!result.allowed && result.reason).toMatch(/premium/i);
+  });
+
+  it("allows a premium account", () => {
+    expect(
+      canImportTransactions(
+        account({ plan: "PREMIUM", subscriptionStatus: "ACTIVE" }),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("allows a complimentary account even on the FREE plan", () => {
+    expect(
+      canImportTransactions(account({ complimentaryAccess: true })).allowed,
+    ).toBe(true);
   });
 });
 

--- a/lib/utils/entitlements.ts
+++ b/lib/utils/entitlements.ts
@@ -192,6 +192,23 @@ export const canViewReportHistory = (
   };
 };
 
+/**
+ * Whether the account may import transactions from a CSV. Free accounts can't
+ * (import is a Premium migration convenience); premium (or comped) accounts
+ * can. Exporting to CSV is always free and has no gate.
+ */
+export const canImportTransactions = (
+  account: AccountEntitlementFields,
+): CheckResult => {
+  if (isPremium(account)) return { allowed: true };
+
+  return {
+    allowed: false,
+    reason:
+      "Importing transactions from a CSV is a Premium feature. Upgrade to Premium to import your data.",
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Downgrade locking
 //

--- a/lib/utils/transaction-import.test.ts
+++ b/lib/utils/transaction-import.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { TransactionType } from "@prisma/client";
+import {
+  duplicateKey,
+  evaluateImportRow,
+  normalizeName,
+  parseImportedAmount,
+  parseImportedDate,
+  parseImportedType,
+  type ImportRowContext,
+  type RawImportRow,
+} from "@/lib/utils/transaction-import";
+
+describe("parseImportedAmount", () => {
+  it("parses a plain number", () => {
+    expect(parseImportedAmount("12.34")).toBe(12.34);
+  });
+
+  it("strips currency symbols and thousands separators", () => {
+    expect(parseImportedAmount("$1,234.56")).toBe(1234.56);
+  });
+
+  it("treats parentheses as negative", () => {
+    expect(parseImportedAmount("(12.00)")).toBe(-12);
+  });
+
+  it("honours a leading minus", () => {
+    expect(parseImportedAmount("-8.5")).toBe(-8.5);
+  });
+
+  it("honours a trailing minus", () => {
+    expect(parseImportedAmount("8.5-")).toBe(-8.5);
+  });
+
+  it("returns null for empty or non-numeric input", () => {
+    expect(parseImportedAmount("")).toBeNull();
+    expect(parseImportedAmount("   ")).toBeNull();
+    expect(parseImportedAmount("abc")).toBeNull();
+    expect(parseImportedAmount("$")).toBeNull();
+  });
+
+  it("rounds to cents", () => {
+    expect(parseImportedAmount("1.239")).toBe(1.24);
+  });
+});
+
+describe("parseImportedDate", () => {
+  it("passes through ISO dates", () => {
+    expect(parseImportedDate("2024-03-05")).toBe("2024-03-05");
+  });
+
+  it("extracts the date part of an ISO datetime", () => {
+    expect(parseImportedDate("2024-03-05T18:30:00.000Z")).toBe("2024-03-05");
+  });
+
+  it("parses M/D/YYYY US dates", () => {
+    expect(parseImportedDate("3/5/2024")).toBe("2024-03-05");
+    expect(parseImportedDate("03/05/2024")).toBe("2024-03-05");
+  });
+
+  it("parses M-D-YYYY and 2-digit years", () => {
+    expect(parseImportedDate("3-5-24")).toBe("2024-03-05");
+  });
+
+  it("rejects impossible dates", () => {
+    expect(parseImportedDate("2/31/2024")).toBeNull();
+    expect(parseImportedDate("13/1/2024")).toBeNull();
+  });
+
+  it("returns null for empty/unparseable input", () => {
+    expect(parseImportedDate("")).toBeNull();
+    expect(parseImportedDate("not a date")).toBeNull();
+  });
+});
+
+describe("parseImportedType", () => {
+  it("maps enum names and synonyms", () => {
+    expect(parseImportedType("RETURN")).toBe(TransactionType.RETURN);
+    expect(parseImportedType("refund")).toBe(TransactionType.RETURN);
+    expect(parseImportedType("Income")).toBe(TransactionType.INCOME);
+    expect(parseImportedType("deposit")).toBe(TransactionType.INCOME);
+    expect(parseImportedType("card payment")).toBe(
+      TransactionType.CARD_PAYMENT,
+    );
+  });
+
+  it("defaults to REGULAR for empty/unknown", () => {
+    expect(parseImportedType("")).toBe(TransactionType.REGULAR);
+    expect(parseImportedType("whatever")).toBe(TransactionType.REGULAR);
+    expect(parseImportedType("expense")).toBe(TransactionType.REGULAR);
+  });
+});
+
+describe("duplicateKey", () => {
+  it("is stable across name casing/whitespace", () => {
+    expect(duplicateKey("2024-01-01", 10, "  Coffee ")).toBe(
+      duplicateKey("2024-01-01", 10, "coffee"),
+    );
+  });
+
+  it("differs when amount differs", () => {
+    expect(duplicateKey("2024-01-01", 10, "Coffee")).not.toBe(
+      duplicateKey("2024-01-01", 11, "Coffee"),
+    );
+  });
+});
+
+describe("normalizeName", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeName("  Rent ")).toBe("rent");
+  });
+});
+
+const ctx = (overrides: Partial<ImportRowContext> = {}): ImportRowContext => ({
+  categoriesByName: new Map([
+    ["groceries", { id: "cat-1", name: "Groceries" }],
+    ["rent", { id: "cat-2", name: "Rent" }],
+  ]),
+  cardsByName: new Map([["amex", { id: "card-1", name: "Amex" }]]),
+  existingKeys: new Set<string>(),
+  ...overrides,
+});
+
+const row = (overrides: Partial<RawImportRow> = {}): RawImportRow => ({
+  date: "2024-01-15",
+  name: "Coffee",
+  amount: "4.50",
+  category: "",
+  card: "",
+  type: "",
+  ...overrides,
+});
+
+describe("evaluateImportRow", () => {
+  it("validates a good row", () => {
+    const result = evaluateImportRow(row(), 0, ctx());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.amount).toBe(4.5);
+    expect(result.occurredAt).toBe("2024-01-15");
+    expect(result.transactionType).toBe(TransactionType.REGULAR);
+  });
+
+  it("matches a category case-insensitively", () => {
+    const result = evaluateImportRow(row({ category: "GROCERIES" }), 0, ctx());
+    expect(result.matchedCategoryId).toBe("cat-1");
+    expect(result.matchedCategoryName).toBe("Groceries");
+  });
+
+  it("leaves an unmatched category null without erroring", () => {
+    const result = evaluateImportRow(row({ category: "Dining out" }), 0, ctx());
+    expect(result.matchedCategoryId).toBeNull();
+    expect(result.valid).toBe(true);
+  });
+
+  it("matches a card by name", () => {
+    const result = evaluateImportRow(row({ card: "amex" }), 0, ctx());
+    expect(result.matchedCardId).toBe("card-1");
+  });
+
+  it("flags a missing amount as invalid", () => {
+    const result = evaluateImportRow(row({ amount: "" }), 0, ctx());
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Amount is required");
+  });
+
+  it("flags an invalid date as invalid", () => {
+    const result = evaluateImportRow(row({ date: "nope" }), 0, ctx());
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("Date"))).toBe(true);
+  });
+
+  it("flags a duplicate against existing keys", () => {
+    const result = evaluateImportRow(
+      row(),
+      0,
+      ctx({
+        existingKeys: new Set([duplicateKey("2024-01-15", 4.5, "Coffee")]),
+      }),
+    );
+    expect(result.duplicate).toBe(true);
+    // A duplicate is still valid (importable) — the user chooses to include it.
+    expect(result.valid).toBe(true);
+  });
+});

--- a/lib/utils/transaction-import.ts
+++ b/lib/utils/transaction-import.ts
@@ -1,0 +1,254 @@
+import { TransactionType } from "@prisma/client";
+import { roundToCents } from "@/lib/utils";
+import { toIsoDateString } from "@/lib/utils/csv";
+
+/**
+ * Pure, dependency-light helpers for the CSV transaction import flow
+ * (`src/app/api/transactions/import/route.ts` +
+ * `components/transactions/ImportTransactionsModal.tsx`). Everything here is
+ * side-effect-free so the parsing/matching/validation rules can be unit
+ * tested without a database (see `transaction-import.test.ts`); the route
+ * feeds it lookup maps built from the account's own data.
+ */
+
+/** The transaction fields a user can map a CSV column onto. */
+export type ImportColumnKey =
+  | "date"
+  | "name"
+  | "amount"
+  | "category"
+  | "card"
+  | "type";
+
+/** Columns the user MUST map before a preview/import can run. */
+export const REQUIRED_IMPORT_COLUMNS: ImportColumnKey[] = ["date", "amount"];
+
+/** A single mapped CSV row, all values as raw strings (pre-validation). */
+export interface RawImportRow {
+  date: string;
+  name: string;
+  amount: string;
+  category: string;
+  card: string;
+  type: string;
+}
+
+/** The validated/annotated view of a row shown in the preview step. */
+export interface ImportPreviewRow {
+  index: number;
+  name: string;
+  rawAmount: string;
+  amount: number | null;
+  rawDate: string;
+  occurredAt: string | null;
+  categoryName: string;
+  matchedCategoryId: string | null;
+  matchedCategoryName: string | null;
+  cardName: string;
+  matchedCardId: string | null;
+  transactionType: TransactionType;
+  errors: string[];
+  duplicate: boolean;
+  /** True when the row has no blocking errors and can be imported. */
+  valid: boolean;
+}
+
+/** Minimal lookup entry for category/card name matching. */
+export interface NamedRef {
+  id: string;
+  name: string;
+}
+
+export interface ImportRowContext {
+  /** Category name (lowercased, trimmed) → category. */
+  categoriesByName: Map<string, NamedRef>;
+  /** Card name (lowercased, trimmed) → card. */
+  cardsByName: Map<string, NamedRef>;
+  /** Duplicate keys (see `duplicateKey`) already present in the account. */
+  existingKeys: Set<string>;
+}
+
+/**
+ * Parses a human/bank-formatted amount into a number:
+ * - strips currency symbols, thousands separators, and whitespace
+ * - treats parentheses as a negative (accounting style): `(12.00)` → `-12`
+ * - honours a leading/trailing minus sign
+ * Returns `null` when the value is empty or not a number.
+ */
+export function parseImportedAmount(raw: string): number | null {
+  if (raw == null) return null;
+  let s = String(raw).trim();
+  if (s === "") return null;
+
+  let negative = false;
+  if (/^\(.*\)$/.test(s)) {
+    negative = true;
+    s = s.slice(1, -1);
+  }
+  if (s.endsWith("-")) {
+    negative = true;
+    s = s.slice(0, -1);
+  }
+
+  // Drop everything except digits, sign, and decimal point.
+  s = s.replace(/[^0-9.\-]/g, "");
+  if (s === "" || s === "-" || s === ".") return null;
+
+  const value = Number(s);
+  if (Number.isNaN(value)) return null;
+
+  const signed = negative ? -Math.abs(value) : value;
+  return roundToCents(signed);
+}
+
+/**
+ * Parses a date cell into an ISO `YYYY-MM-DD` string. Accepts ISO dates,
+ * ISO datetimes, and common `M/D/YYYY` (or `M-D-YYYY`) US-style dates.
+ * Returns `null` when empty or unparseable.
+ */
+export function parseImportedDate(raw: string): string | null {
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  if (s === "") return null;
+
+  // Already ISO (date or datetime).
+  if (/^\d{4}-\d{2}-\d{2}(T.*)?$/.test(s)) {
+    return toIsoDateString(s) || null;
+  }
+
+  // M/D/YYYY or M-D-YYYY (also accepts zero-padded and 2-digit years).
+  const slashMatch = /^(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})$/.exec(s);
+  if (slashMatch) {
+    const month = Number(slashMatch[1]);
+    const day = Number(slashMatch[2]);
+    let year = Number(slashMatch[3]);
+    if (year < 100) year += 2000;
+    if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (Number.isNaN(date.getTime())) return null;
+    // Guard against overflow (e.g. 2/31 → Mar 3).
+    if (date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+      return null;
+    }
+    return toIsoDateString(date) || null;
+  }
+
+  // Last resort: let Date try (handles e.g. "Jan 5, 2024").
+  const parsed = new Date(s);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return toIsoDateString(parsed) || null;
+}
+
+/**
+ * Maps a free-text transaction-type cell onto a `TransactionType`. Recognises
+ * the enum names and a few common synonyms; defaults to `REGULAR` when empty
+ * or unrecognised.
+ */
+export function parseImportedType(raw: string): TransactionType {
+  const s = String(raw ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_");
+  switch (s) {
+    case "RETURN":
+    case "REFUND":
+      return TransactionType.RETURN;
+    case "INCOME":
+    case "DEPOSIT":
+      return TransactionType.INCOME;
+    case "CARD_PAYMENT":
+    case "PAYMENT":
+      return TransactionType.CARD_PAYMENT;
+    case "REGULAR":
+    case "EXPENSE":
+    case "PURCHASE":
+    default:
+      return TransactionType.REGULAR;
+  }
+}
+
+/** Normalizes a name for case-insensitive matching/deduping. */
+export function normalizeName(name: string): string {
+  return String(name ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Builds the duplicate-detection key for a row: date + amount + name. Two
+ * rows (or a row and an existing transaction) collide when all three match,
+ * so a re-import of the same file flags every previously-imported row.
+ */
+export function duplicateKey(
+  isoDate: string,
+  amount: number,
+  name: string,
+): string {
+  return `${isoDate}|${amount.toFixed(2)}|${normalizeName(name)}`;
+}
+
+/**
+ * Validates and annotates a single mapped row against the account's data.
+ * Never throws — blocking problems land in `errors` and set `valid = false`;
+ * an unmatched category is not an error (the row imports uncategorized).
+ */
+export function evaluateImportRow(
+  raw: RawImportRow,
+  index: number,
+  ctx: ImportRowContext,
+): ImportPreviewRow {
+  const errors: string[] = [];
+
+  const name = (raw.name ?? "").trim();
+  const rawAmount = (raw.amount ?? "").trim();
+  const rawDate = (raw.date ?? "").trim();
+  const categoryName = (raw.category ?? "").trim();
+  const cardName = (raw.card ?? "").trim();
+
+  const amount = parseImportedAmount(rawAmount);
+  if (amount === null) {
+    errors.push(
+      rawAmount === "" ? "Amount is required" : "Amount is not a number",
+    );
+  }
+
+  const occurredAt = parseImportedDate(rawDate);
+  if (occurredAt === null) {
+    errors.push(
+      rawDate === "" ? "Date is required" : "Date is not a valid date",
+    );
+  }
+
+  const transactionType = parseImportedType(raw.type ?? "");
+
+  const matchedCategory = categoryName
+    ? (ctx.categoriesByName.get(normalizeName(categoryName)) ?? null)
+    : null;
+
+  const matchedCard = cardName
+    ? (ctx.cardsByName.get(normalizeName(cardName)) ?? null)
+    : null;
+
+  const duplicate =
+    amount !== null && occurredAt !== null
+      ? ctx.existingKeys.has(duplicateKey(occurredAt, amount, name))
+      : false;
+
+  return {
+    index,
+    name,
+    rawAmount,
+    amount,
+    rawDate,
+    occurredAt,
+    categoryName,
+    matchedCategoryId: matchedCategory?.id ?? null,
+    matchedCategoryName: matchedCategory?.name ?? null,
+    cardName,
+    matchedCardId: matchedCard?.id ?? null,
+    transactionType,
+    errors,
+    duplicate,
+    valid: errors.length === 0,
+  };
+}

--- a/src/app/api/transactions/export/route.ts
+++ b/src/app/api/transactions/export/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import { getTransactionsForExport } from "@/lib/api-services/transactions";
+import { buildCsv, toIsoDateString } from "@/lib/utils/csv";
+import type { User } from "@prisma/client";
+
+// Exporting transactions to CSV is FREE (a trust signal — a user's data is
+// never held hostage), so there is intentionally no entitlement gate here.
+export const GET = withUser({
+  GET: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const { headers, rows } = await prisma.$transaction((tx) =>
+        getTransactionsForExport(tx, user.accountId),
+      );
+
+      const csv = buildCsv(headers, rows);
+      const filename = `ronin-transactions-${toIsoDateString(new Date())}.csv`;
+
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+      });
+    },
+  ),
+});

--- a/src/app/api/transactions/import/route.ts
+++ b/src/app/api/transactions/import/route.ts
@@ -1,0 +1,116 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import {
+  createTransactionsBatch,
+  getImportContext,
+} from "@/lib/api-services/transactions";
+import {
+  importTransactionsSchema,
+  type CreateTransactionSchema,
+} from "@/lib/api-schemas/transactions";
+import {
+  evaluateImportRow,
+  type ImportPreviewRow,
+} from "@/lib/utils/transaction-import";
+import type { User } from "@prisma/client";
+import {
+  BUDGET_LOCKED_REASON,
+  getAccountEntitlements,
+  isBudgetWriteLocked,
+  paymentRequired,
+} from "@/lib/api-services/entitlements";
+import { canImportTransactions } from "@/lib/utils/entitlements";
+
+// CSV import is PREMIUM (a migration convenience from Mint/YNAB/bank exports).
+// The endpoint runs in two modes:
+//   - preview (commit: false): validate + annotate rows (category matches,
+//     duplicate flags) so the client can render the confirmation step.
+//   - commit (commit: true): insert the valid rows via the shared batch path.
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = (await req.json()) as unknown;
+      const validationResult = importTransactionsSchema.safeParse(body);
+
+      if (!validationResult.success) {
+        return NextResponse.json(
+          {
+            message: "Validation failed",
+            errors: validationResult.error.errors,
+          },
+          { status: 400 },
+        );
+      }
+
+      const { budgetId, rows, commit } = validationResult.data;
+
+      // Premium gate — return (do not throw) so the 402 keeps the
+      // { error, upgradeRequired } shape the client's parseErrorResponse
+      // expects to open the UpgradeModal.
+      const account = await getAccountEntitlements(prisma, user.accountId);
+      const entitlementCheck = canImportTransactions(account);
+      if (!entitlementCheck.allowed) {
+        return paymentRequired(entitlementCheck.reason);
+      }
+
+      // A locked (read-only after downgrade) budget also can't receive imports.
+      if (await isBudgetWriteLocked(prisma, user.accountId, budgetId)) {
+        return paymentRequired(BUDGET_LOCKED_REASON);
+      }
+
+      return await prisma.$transaction(async (tx) => {
+        const { budgetName, context } = await getImportContext(
+          tx,
+          user.accountId,
+          budgetId,
+        );
+
+        const preview: ImportPreviewRow[] = rows.map((row, index) =>
+          evaluateImportRow(row, index, context),
+        );
+
+        if (!commit) {
+          return NextResponse.json({ budgetName, preview }, { status: 200 });
+        }
+
+        const validRows = preview.filter((r) => r.valid);
+        if (validRows.length === 0) {
+          return NextResponse.json(
+            { message: "No valid rows to import" },
+            { status: 400 },
+          );
+        }
+
+        const transactions: CreateTransactionSchema[] = validRows.map((r) => ({
+          budgetId,
+          name: r.name || undefined,
+          amount: r.amount!,
+          categoryId: r.matchedCategoryId ?? undefined,
+          cardId: r.matchedCardId ?? undefined,
+          transactionType: r.transactionType,
+          occurredAt: r.occurredAt ?? undefined,
+        }));
+
+        const created = await createTransactionsBatch(
+          tx,
+          { transactions },
+          user,
+        );
+
+        return NextResponse.json(
+          {
+            imported: created.length,
+            skipped: preview.length - created.length,
+          },
+          { status: 200 },
+        );
+      });
+    },
+  ),
+});

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -30,6 +30,8 @@ import {
   ScanLine,
   ChevronDown,
   Repeat,
+  Download,
+  Upload,
 } from "lucide-react";
 import PageHeader from "@/components/PageHeader";
 import DeleteConfirmationModal from "@/components/DeleteConfirmationModal";
@@ -38,6 +40,7 @@ import { usePageLoading } from "@/components/ConditionalLayout";
 import { useMobileHeaderAction } from "@/components/MobileHeaderActionContext";
 import AddTransactionModal from "@/components/transactions/AddTransactionModal";
 import ReceiptScanModal from "@/components/transactions/ReceiptScanModal";
+import ImportTransactionsModal from "@/components/transactions/ImportTransactionsModal";
 import InlineTransactionEdit from "@/components/transactions/InlineTransactionEdit";
 import TransactionsPageNavigation from "@/components/transactions/TransactionsPageNavigation";
 import TransactionFiltersModal, {
@@ -49,6 +52,8 @@ import TransactionFiltersModal, {
 import type { TransactionWithRelations } from "@/lib/types/transaction";
 import Button from "@/components/Button";
 import StatsCard from "@/components/StatsCard";
+import { useBillingStatus } from "@/lib/data-hooks/billing/useBilling";
+import { exportTransactionsCsv } from "@/lib/data-hooks/services/transactions";
 import {
   getGroupColor,
   getCategoryBadgeColor,
@@ -141,8 +146,28 @@ const TransactionsPageContent = () => {
   );
   const [showAddTransactionModal, setShowAddTransactionModal] = useState(false);
   const [showReceiptScanModal, setShowReceiptScanModal] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
   const [showFiltersModal, setShowFiltersModal] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const { data: billingStatus } = useBillingStatus();
+  const isPremium = billingStatus?.isPremium ?? false;
   const { setMobileHeaderAction } = useMobileHeaderAction();
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      await exportTransactionsCsv();
+    } catch (err) {
+      console.error("Failed to export transactions:", err);
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to export transactions. Please try again.",
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   // Register the mobile header's scan-receipt shortcut; clean up on unmount
   // so it doesn't leak into other pages.
@@ -630,6 +655,20 @@ const TransactionsPageContent = () => {
             icon: <ScanLine className="h-4 w-4" />,
             variant: "outline",
           },
+          {
+            label: "Import",
+            onClick: () => setShowImportModal(true),
+            icon: <Upload className="h-4 w-4" />,
+            variant: "outline",
+          },
+          {
+            label: isExporting ? "Exporting…" : "Export",
+            onClick: () => {
+              if (!isExporting) void handleExport();
+            },
+            icon: <Download className="h-4 w-4" />,
+            variant: "outline",
+          },
         ]}
       />
 
@@ -733,6 +772,13 @@ const TransactionsPageContent = () => {
             <ReceiptScanModal
               isOpen={showReceiptScanModal}
               onClose={() => setShowReceiptScanModal(false)}
+            />
+
+            {/* Import Transactions Modal (premium; free users see a paywall) */}
+            <ImportTransactionsModal
+              isOpen={showImportModal}
+              onClose={() => setShowImportModal(false)}
+              canImport={isPremium}
             />
 
             {/* Filters Modal */}


### PR DESCRIPTION
## Feature 4 — CSV import/export

Stacked on #95 (Feature 3). Export is free (your data is never hostage); import is premium (migration from Mint/YNAB/bank exports). No new DB models, **no new dependencies** (hand-rolled RFC-4180 parser).

### Export (free)
- `GET /api/transactions/export` → `text/csv` attachment. Columns: Date, Name, Description, Amount, Type, Category, Card, Budget. ISO dates (`occurredAt ?? createdAt`), category/card/budget **names** not IDs (split txns join split category names), respects `deleted: null`. RFC-4180 escaping (quote-wrap `,`/`"`/CRLF, doubled quotes). Export button on the transactions page.

### Import (premium)
- `POST /api/transactions/import` with `{ budgetId, rows, commit }`: `commit:false` → validated/annotated preview; `commit:true` → inserts valid rows via the existing `createTransactionsBatch` in one `prisma.$transaction`.
- Parsing is client-side (`parseCsv`) — the file never leaves the browser. Modal flow: upload → column mapping (date/amount required; name/category/card/type optional, auto-guessed from headers) → preview w/ per-row validation + duplicate flags → confirm.
- **Budget**: rows post into a user-selected active budget (premium accounts can have several); server rejects non-active/missing with 400.
- **Category matching**: case-insensitive exact name match against the budget's categories; unmatched → `categoryId` null (no failure).
- **Duplicate guard**: keys on date + amount(2dp) + normalized name vs existing transactions; flagged rows default excluded, user can re-include.
- **Gate**: `return paymentRequired(canImportTransactions(account).reason)` (402) + budget-write-lock check → client `UpgradeRequiredError` → `UpgradeModal`; free users see the paywall immediately.

### Pure + tested
`lib/utils/csv.ts` (22 tests) and `lib/utils/transaction-import.ts` (`parseImportedAmount`/`parseImportedDate`/`parseImportedType`/`duplicateKey`/`evaluateImportRow`, 25 tests). `canImportTransactions` added to entitlements (+ tests).

`pnpm check` clean; 173/173 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)