### PR TITLE
Feature 5: Notifications (in-app free, web push premium)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -123,3 +123,26 @@ shadow-soft` translating via `translate-x-6` / `translate-x-1`. Disabled
 5. Check at 375 px: touch targets, bottom-nav clearance (`pb-24 lg:pb-8`), no
    hover-only actions.
 6. Run `pnpm check` (lint + typecheck) before committing.
+
+## 10. Notifications (bell + panel)
+
+Introduced with in-app/push notifications (Feature 5). Reuse this pattern for
+any future alert/inbox UI rather than inventing another one.
+
+- **Bell button**: `components/notifications/NotificationBell.tsx` — a 44px
+  icon button (`Bell` from lucide-react) with an unread-count badge
+  (`bg-secondary`, `text-primary-950`, pill, top-right of the icon, "9+" once
+  it clips). Lives in the dark `SideNav` header row (`variant="dark"`) and the
+  light `MobileHeader` action row (`variant="light"`, default) — both gated on
+  the account's `notifications` feature toggle being on.
+- **Panel**: `components/notifications/NotificationPanel.tsx` — the standard
+  `Modal` in `sheet` variant (bottom sheet on mobile, centered dialog at
+  `sm:` and up), titled "Notifications", with a "Mark all as read" button in
+  the footer when there's anything unread. Rows: a `bg-secondary` unread dot,
+  title (`text-sm font-medium`), body (`text-xs text-gray-500`, 2-line clamp),
+  relative timestamp (`text-xs text-gray-400`). Clicking a row marks it read
+  and navigates to its target (see `notificationLink.ts`); empty state
+  follows the standard icon-in-a-circle + headline + helper text pattern.
+- **Settings toggles**: per-trigger and push on/off rows use the shared
+  `components/settings/ToggleRow.tsx` (extracted from the Features tab) — the
+  same switch described in §7 "Toggle rows", never a bespoke checkbox.

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -3,12 +3,18 @@
 import Image from "next/image";
 import roninLogo from "@/public/ronin_logo.jpg";
 import { useMobileHeaderAction } from "./MobileHeaderActionContext";
+import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { isFeatureEnabled } from "@/lib/utils/features";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
+import NotificationBell from "@/components/notifications/NotificationBell";
 
 // Slim mobile top bar. Primary navigation now lives in the MobileBottomNav;
 // this keeps the brand mark up top plus an optional page-registered action
-// (e.g. scan receipt) rendered on the right via MobileHeaderActionContext.
+// (e.g. scan receipt) and the notifications bell on the right.
 export default function MobileHeader() {
   const { action } = useMobileHeaderAction();
+  const { data: featureSettings } = useFeatureSettings();
+  const settings = featureSettings ?? DEFAULT_FEATURE_SETTINGS;
 
   return (
     <div className="fixed left-0 right-0 top-0 z-[60] border-b border-gray-200/70 bg-surface-card/90 backdrop-blur-md lg:hidden">
@@ -30,18 +36,22 @@ export default function MobileHeader() {
           </h1>
         </div>
 
-        {/* Page-registered action (e.g. scan receipt) */}
-        {action && (
-          <button
-            type="button"
-            onClick={action.onClick}
-            aria-label={action.label}
-            title={action.label}
-            className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl text-gray-600 transition-all duration-200 ease-out hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 active:scale-[0.98]"
-          >
-            {action.icon}
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {/* Page-registered action (e.g. scan receipt) */}
+          {action && (
+            <button
+              type="button"
+              onClick={action.onClick}
+              aria-label={action.label}
+              title={action.label}
+              className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl text-gray-600 transition-all duration-200 ease-out hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 active:scale-[0.98]"
+            >
+              {action.icon}
+            </button>
+          )}
+
+          {isFeatureEnabled(settings, "notifications") && <NotificationBell />}
+        </div>
       </div>
     </div>
   );

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -23,6 +23,7 @@ import { signOut, useSession } from "next-auth/react";
 import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
 import { isFeatureEnabled } from "@/lib/utils/features";
 import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
+import NotificationBell from "@/components/notifications/NotificationBell";
 
 interface SideNavProps {
   isCollapsed: boolean;
@@ -88,27 +89,34 @@ export default function SideNav({ isCollapsed, setIsCollapsed }: SideNavProps) {
       <div className="flex h-full flex-col p-3">
         {/**logo*/}
         <div
-          className={`mb-8 mt-2 flex items-center overflow-hidden ${isCollapsed ? "justify-center" : "gap-3 px-2"}`}
+          className={`mb-8 mt-2 flex items-center overflow-hidden ${isCollapsed ? "flex-col gap-2" : "justify-between gap-3 px-2"}`}
         >
           <div
-            className={`flex-shrink-0 ${isCollapsed ? "h-10 w-10" : "h-12 w-12"}`}
+            className={`flex items-center overflow-hidden ${isCollapsed ? "justify-center" : "gap-3"}`}
           >
-            <Image
-              src="/ronin_logo.jpg"
-              alt="Ronin Logo"
-              width={isCollapsed ? 48 : 64}
-              height={isCollapsed ? 48 : 64}
-              className="h-full w-full rounded-full ring-2 ring-secondary/40"
-              priority
-            />
+            <div
+              className={`flex-shrink-0 ${isCollapsed ? "h-10 w-10" : "h-12 w-12"}`}
+            >
+              <Image
+                src="/ronin_logo.jpg"
+                alt="Ronin Logo"
+                width={isCollapsed ? 48 : 64}
+                height={isCollapsed ? 48 : 64}
+                className="h-full w-full rounded-full ring-2 ring-secondary/40"
+                priority
+              />
+            </div>
+            <div
+              className={`transition-all duration-300 ease-in-out ${isCollapsed ? "w-0 opacity-0" : "w-auto opacity-100"}`}
+            >
+              <h2 className="whitespace-nowrap text-lg font-bold tracking-[0.2em] text-secondary">
+                RONIN
+              </h2>
+            </div>
           </div>
-          <div
-            className={`transition-all duration-300 ease-in-out ${isCollapsed ? "w-0 opacity-0" : "w-auto opacity-100"}`}
-          >
-            <h2 className="whitespace-nowrap text-lg font-bold tracking-[0.2em] text-secondary">
-              RONIN
-            </h2>
-          </div>
+          {isFeatureEnabled(settings, "notifications") && (
+            <NotificationBell variant="dark" />
+          )}
         </div>
 
         <nav className="flex flex-col gap-1">

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { Bell } from "lucide-react";
+import { useNotifications } from "@/lib/data-hooks/notifications/useNotifications";
+import NotificationPanel from "./NotificationPanel";
+
+interface NotificationBellProps {
+  /** `dark` matches the dark SideNav chrome; `light` matches MobileHeader /
+   * light surfaces. Defaults to `light`. */
+  variant?: "dark" | "light";
+  className?: string;
+}
+
+/**
+ * Bell icon + unread badge, opening `NotificationPanel` on click. Shared
+ * between the desktop `SideNav` and mobile `MobileHeader` — see DESIGN.md
+ * §10 for the notification bell/panel pattern this introduces.
+ */
+export default function NotificationBell({
+  variant = "light",
+  className = "",
+}: NotificationBellProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data } = useNotifications();
+  const unreadCount = data?.unreadCount ?? 0;
+
+  const colorClasses =
+    variant === "dark"
+      ? "text-primary-300 hover:bg-white/5 hover:text-white"
+      : "text-gray-600 hover:bg-gray-100 hover:text-gray-900";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label={
+          unreadCount > 0
+            ? `Notifications, ${unreadCount} unread`
+            : "Notifications"
+        }
+        className={`relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-all duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 active:scale-[0.98] ${colorClasses} ${className}`}
+      >
+        <Bell className="h-5 w-5" strokeWidth={1.8} />
+        {unreadCount > 0 && (
+          <span className="absolute right-2 top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-secondary px-1 text-[10px] font-semibold leading-none text-primary-950">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      <NotificationPanel isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/components/notifications/NotificationPanel.tsx
+++ b/components/notifications/NotificationPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Bell, CheckCheck } from "lucide-react";
+import Modal from "@/components/Modal";
+import Button from "@/components/Button";
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+} from "@/lib/data-hooks/notifications/useNotifications";
+import type { SerializedNotification } from "@/lib/types/notification";
+import { getNotificationLink } from "./notificationLink";
+
+interface NotificationPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/** Short relative time for a notification's `createdAt` — "Just now", "5m
+ * ago", "3h ago", "2d ago", then a plain date once it's more than a week old. */
+const formatRelativeTime = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (seconds < 60) return "Just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+};
+
+const NotificationRow = ({
+  notification,
+  onNavigate,
+}: {
+  notification: SerializedNotification;
+  onNavigate: (notification: SerializedNotification) => void;
+}) => {
+  const isUnread = notification.readAt === null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(notification)}
+      className={`flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors duration-200 ease-out hover:bg-gray-100 ${
+        isUnread ? "bg-secondary/5" : ""
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
+          isUnread ? "bg-secondary" : "bg-transparent"
+        }`}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-gray-900">
+          {notification.title}
+        </p>
+        <p className="mt-0.5 line-clamp-2 text-xs text-gray-500">
+          {notification.body}
+        </p>
+        <p className="mt-1 text-xs text-gray-400">
+          {formatRelativeTime(notification.createdAt)}
+        </p>
+      </div>
+    </button>
+  );
+};
+
+export default function NotificationPanel({
+  isOpen,
+  onClose,
+}: NotificationPanelProps) {
+  const router = useRouter();
+  const { data, isLoading } = useNotifications();
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+
+  const notifications = data?.notifications ?? [];
+  const unreadCount = data?.unreadCount ?? 0;
+
+  const handleNavigate = (notification: SerializedNotification) => {
+    if (notification.readAt === null) {
+      markRead.mutate(notification.id);
+    }
+    const link = getNotificationLink(notification);
+    onClose();
+    if (link) router.push(link);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Notifications"
+      variant="sheet"
+      maxWidth="max-w-md"
+      footer={
+        unreadCount > 0 ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => markAllRead.mutate()}
+            isLoading={markAllRead.isPending}
+          >
+            <CheckCheck className="mr-2 h-4 w-4" />
+            Mark all as read
+          </Button>
+        ) : undefined
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-xl bg-surface-muted"
+            />
+          ))}
+        </div>
+      ) : notifications.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-surface-muted">
+            <Bell className="h-5 w-5 text-gray-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-900">
+              No notifications yet
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              We&apos;ll let you know about budget thresholds and recurring
+              transactions here.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {notifications.map((notification) => (
+            <NotificationRow
+              key={notification.id}
+              notification={notification}
+              onNavigate={handleNavigate}
+            />
+          ))}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/components/notifications/notificationLink.ts
+++ b/components/notifications/notificationLink.ts
@@ -1,0 +1,31 @@
+import type {
+  BudgetPeriodEndingData,
+  CategoryOverThresholdData,
+  SerializedNotification,
+} from "@/lib/types/notification";
+
+/**
+ * Resolves the page a notification should navigate to when clicked, based on
+ * its `type` + `data` payload (see the `evaluate*` functions in
+ * lib/utils/notifications.ts for what `data` holds per type — `RecurringPostedData`
+ * has no destination field of its own, since it always routes to the same
+ * page). Returns `null` for a type with no natural destination.
+ */
+export const getNotificationLink = (
+  notification: Pick<SerializedNotification, "type" | "data">,
+): string | null => {
+  switch (notification.type) {
+    case "CATEGORY_OVER_THRESHOLD": {
+      const data = notification.data as CategoryOverThresholdData | null;
+      return data?.budgetId ? `/budgets/${data.budgetId}/categories` : null;
+    }
+    case "BUDGET_PERIOD_ENDING": {
+      const data = notification.data as BudgetPeriodEndingData | null;
+      return data?.budgetId ? `/budgets/${data.budgetId}` : null;
+    }
+    case "RECURRING_POSTED":
+      return "/transactions/recurring";
+    default:
+      return null;
+  }
+};

--- a/components/settings/FeatureToggles.tsx
+++ b/components/settings/FeatureToggles.tsx
@@ -6,50 +6,12 @@ import {
   useFeatureSettings,
   useUpdateFeatureSettings,
 } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import ToggleRow from "./ToggleRow";
 
 interface FeatureTogglesProps {
   /** Only ADMIN users may flip a toggle; everyone else sees them disabled. */
   isAdmin: boolean;
 }
-
-/** A single on/off row: label + description on the left, switch on the right. */
-const ToggleRow = ({
-  label,
-  description,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  description: string;
-  checked: boolean;
-  disabled: boolean;
-  onChange: () => void;
-}) => (
-  <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
-    <div className="min-w-0">
-      <p className="text-sm font-medium text-gray-900">{label}</p>
-      <p className="mt-0.5 text-xs text-gray-500">{description}</p>
-    </div>
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      disabled={disabled}
-      onClick={onChange}
-      className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-200 ease-out ${
-        checked ? "bg-secondary" : "bg-gray-200"
-      } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
-    >
-      <span
-        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-soft transition-transform duration-200 ease-out ${
-          checked ? "translate-x-6" : "translate-x-1"
-        }`}
-      />
-    </button>
-  </div>
-);
 
 export default function FeatureToggles({ isAdmin }: FeatureTogglesProps) {
   const { data: settings, isLoading } = useFeatureSettings();

--- a/components/settings/NotificationSettingsPanel.tsx
+++ b/components/settings/NotificationSettingsPanel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "react-hot-toast";
+import ToggleRow from "./ToggleRow";
+import UpgradeModal from "@/components/UpgradeModal";
+import {
+  NOTIFICATION_TRIGGERS,
+  type NotificationTriggerKey,
+} from "@/lib/types/notification-settings";
+import {
+  useNotificationSettingsOrDefault,
+  useUpdateNotificationSettings,
+} from "@/lib/data-hooks/notifications/useNotificationSettings";
+import {
+  useSubscribeToPush,
+  useUnsubscribeFromPush,
+} from "@/lib/data-hooks/notifications/usePushSubscription";
+import {
+  getExistingPushSubscription,
+  isPushSupported,
+  needsIosHomeScreenInstall,
+} from "@/lib/utils/push-client";
+import { UpgradeRequiredError } from "@/lib/data-hooks/services/http";
+
+/**
+ * Per-user notification preferences — the "Notifications" settings tab.
+ * Only rendered when the account-wide `notifications` feature toggle is on
+ * (see the tab visibility check in src/app/settings/page.tsx) — that toggle
+ * is the master switch; these are per-trigger refinements underneath it.
+ */
+export default function NotificationSettingsPanel() {
+  const { data: settings, isLoading } = useNotificationSettingsOrDefault();
+  const updateSettings = useUpdateNotificationSettings();
+  const subscribeMutation = useSubscribeToPush();
+  const unsubscribeMutation = useUnsubscribeFromPush();
+
+  const [pushSubscribed, setPushSubscribed] = useState<boolean | null>(null);
+  const [upgradeReason, setUpgradeReason] = useState<string | null>(null);
+  const [pushSupported, setPushSupported] = useState(true);
+  const [needsIosInstall, setNeedsIosInstall] = useState(false);
+
+  // Feature-detection and the current subscription state only exist in the
+  // browser — read them after mount so this never runs during SSR.
+  useEffect(() => {
+    setPushSupported(isPushSupported());
+    setNeedsIosInstall(needsIosHomeScreenInstall());
+    void getExistingPushSubscription().then((subscription) =>
+      setPushSubscribed(subscription !== null),
+    );
+  }, []);
+
+  const handleToggleTrigger = async (key: NotificationTriggerKey) => {
+    const next = !settings[key];
+    try {
+      await updateSettings.mutateAsync({ [key]: next });
+      toast.success(
+        next ? "Notification turned on" : "Notification turned off",
+      );
+    } catch (error) {
+      console.error("Failed to update notification settings:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update notification settings. Please try again.",
+      );
+    }
+  };
+
+  const handleTogglePush = async () => {
+    if (pushSubscribed) {
+      try {
+        await unsubscribeMutation.mutateAsync();
+        setPushSubscribed(false);
+        toast.success("Push notifications turned off");
+      } catch (error) {
+        console.error("Failed to unsubscribe from push:", error);
+        toast.error("Failed to turn off push notifications. Please try again.");
+      }
+      return;
+    }
+
+    try {
+      await subscribeMutation.mutateAsync();
+      setPushSubscribed(true);
+      toast.success("Push notifications turned on");
+    } catch (error) {
+      if (error instanceof UpgradeRequiredError) {
+        setUpgradeReason(error.message);
+        return;
+      }
+      console.error("Failed to subscribe to push:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to turn on push notifications. Please try again.",
+      );
+    }
+  };
+
+  const pushMutationPending =
+    subscribeMutation.isPending || unsubscribeMutation.isPending;
+
+  return (
+    <>
+      <div className="space-y-4 sm:space-y-6">
+        <div className="card-surface p-5 sm:p-6">
+          <h3 className="text-base font-semibold tracking-tight text-gray-900">
+            Alerts
+          </h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Choose which events notify you in-app.
+          </p>
+
+          <div className="mt-4 divide-y divide-gray-200/70">
+            {isLoading
+              ? NOTIFICATION_TRIGGERS.map((trigger) => (
+                  <div
+                    key={trigger.key}
+                    className="h-14 animate-pulse py-3 first:pt-0 last:pb-0"
+                  >
+                    <div className="h-full rounded-xl bg-surface-muted" />
+                  </div>
+                ))
+              : NOTIFICATION_TRIGGERS.map((trigger) => (
+                  <ToggleRow
+                    key={trigger.key}
+                    label={trigger.label}
+                    description={trigger.description}
+                    checked={settings[trigger.key]}
+                    disabled={updateSettings.isPending}
+                    onChange={() => void handleToggleTrigger(trigger.key)}
+                  />
+                ))}
+          </div>
+        </div>
+
+        <div className="card-surface p-5 sm:p-6">
+          <h3 className="text-base font-semibold tracking-tight text-gray-900">
+            Push notifications
+          </h3>
+          <p className="mt-1 text-sm text-gray-600">
+            Get alerted outside the app, even when Ronin isn&apos;t open. A
+            Premium feature.
+          </p>
+
+          {!pushSupported ? (
+            <p className="mt-4 rounded-xl bg-surface-muted p-3 text-sm text-gray-600">
+              This browser doesn&apos;t support push notifications.
+            </p>
+          ) : needsIosInstall ? (
+            <p className="mt-4 rounded-xl bg-secondary-50 p-3 text-sm text-secondary-800">
+              On iPhone/iPad, add Ronin to your home screen first (Share → Add
+              to Home Screen) — iOS only allows push notifications from an
+              installed app.
+            </p>
+          ) : (
+            <div className="mt-4">
+              <ToggleRow
+                label="Push notifications"
+                description="Mirror your in-app alerts as push notifications on this device."
+                checked={pushSubscribed === true}
+                disabled={pushSubscribed === null || pushMutationPending}
+                onChange={() => void handleTogglePush()}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <UpgradeModal
+        isOpen={upgradeReason !== null}
+        onClose={() => setUpgradeReason(null)}
+        reason={upgradeReason ?? undefined}
+      />
+    </>
+  );
+}

--- a/components/settings/ToggleRow.tsx
+++ b/components/settings/ToggleRow.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// A single on/off row: label + description on the left, pill switch on the
+// right. See DESIGN.md §7 "Toggle rows". Shared by FeatureToggles and the
+// Notifications settings tab so every settings toggle looks identical.
+export default function ToggleRow({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900">{label}</p>
+        <p className="mt-0.5 text-xs text-gray-500">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={onChange}
+        className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-200 ease-out ${
+          checked ? "bg-secondary" : "bg-gray-200"
+        } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+      >
+        <span
+          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-soft transition-transform duration-200 ease-out ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/lib/api-schemas/notification-settings.ts
+++ b/lib/api-schemas/notification-settings.ts
@@ -1,0 +1,15 @@
+import type { z } from "zod";
+import { notificationSettingsSchema } from "@/lib/types/notification-settings";
+
+/**
+ * Body shape accepted by `PATCH /api/users/notification-settings` — any
+ * subset of the trigger keys. The service layer merges this over the user's
+ * existing (parsed-with-fallback) settings, so omitted keys are untouched.
+ * Mirrors `updateFeatureSettingsSchema`.
+ */
+export const updateNotificationSettingsSchema =
+  notificationSettingsSchema.partial();
+
+export type UpdateNotificationSettingsSchema = z.infer<
+  typeof updateNotificationSettingsSchema
+>;

--- a/lib/api-schemas/push.ts
+++ b/lib/api-schemas/push.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * Body shape accepted by `POST /api/notifications/push` — the JSON produced
+ * by the browser's `PushSubscription.toJSON()`. Creation is gated by
+ * `canUsePushNotifications` (Premium only) in the route handler.
+ */
+export const createPushSubscriptionSchema = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1),
+  }),
+});
+
+/** Body shape accepted by `DELETE /api/notifications/push` — just the
+ * endpoint being torn down. Never gated — unsubscribing is always allowed. */
+export const deletePushSubscriptionSchema = z.object({
+  endpoint: z.string().url(),
+});
+
+export type CreatePushSubscriptionSchema = z.infer<
+  typeof createPushSubscriptionSchema
+>;
+export type DeletePushSubscriptionSchema = z.infer<
+  typeof deletePushSubscriptionSchema
+>;

--- a/lib/api-services/notification-settings.ts
+++ b/lib/api-services/notification-settings.ts
@@ -1,0 +1,56 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { HttpError } from "../errors";
+import {
+  parseNotificationSettings,
+  type NotificationSettings,
+} from "../types/notification-settings";
+import type { UpdateNotificationSettingsSchema } from "../api-schemas/notification-settings";
+
+type UserPrisma = Pick<PrismaClient, "user">;
+
+/** Loads a user's per-trigger notification preferences, parsed-with-fallback. */
+export const getNotificationSettings = async (
+  prisma: UserPrisma,
+  userId: string,
+): Promise<NotificationSettings> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { notificationSettings: true },
+  });
+
+  if (!user) {
+    throw new HttpError("User not found", 404);
+  }
+
+  return parseNotificationSettings(user.notificationSettings);
+};
+
+/**
+ * Merges `patch` over the user's existing (parsed-with-fallback) notification
+ * settings and persists the full, complete object. Mirrors
+ * `updateFeatureSettings`, scoped to a user instead of an account.
+ */
+export const updateNotificationSettings = async (
+  tx: UserPrisma,
+  userId: string,
+  patch: UpdateNotificationSettingsSchema,
+): Promise<NotificationSettings> => {
+  const user = await tx.user.findUnique({
+    where: { id: userId },
+    select: { notificationSettings: true },
+  });
+
+  if (!user) {
+    throw new HttpError("User not found", 404);
+  }
+
+  const current = parseNotificationSettings(user.notificationSettings);
+  const merged: NotificationSettings = { ...current, ...patch };
+
+  await tx.user.update({
+    where: { id: userId },
+    data: { notificationSettings: merged as Prisma.InputJsonValue },
+  });
+
+  return merged;
+};

--- a/lib/api-services/notifications.ts
+++ b/lib/api-services/notifications.ts
@@ -1,0 +1,392 @@
+import type { Prisma } from "@prisma/client";
+import type { PrismaClientTx } from "../prisma";
+import { HttpError } from "../errors";
+import { calculateCategorySpent } from "../utils/spending";
+import {
+  dedupeNotificationTargets,
+  evaluateBudgetPeriodEnding,
+  evaluateCategoryThreshold,
+  notificationIdentityKey,
+  type NotificationCandidate,
+  type NotificationTarget,
+} from "../utils/notifications";
+import { parseFeatureSettings } from "../types/feature-settings";
+import { parseNotificationSettings } from "../types/notification-settings";
+import { isPremium } from "../utils/entitlements";
+import { getAccountEntitlements } from "./entitlements";
+import { sendPushNotification } from "@/server/push";
+import { deletePushSubscriptionByEndpoint } from "./push";
+
+type NotificationPrisma = Pick<
+  PrismaClientTx,
+  "notification" | "account" | "accountUser" | "budget" | "pushSubscription"
+>;
+
+// ---------------------------------------------------------------------------
+// Inbox: reading and marking notifications read for the current user.
+// ---------------------------------------------------------------------------
+
+const NOTIFICATION_LIST_LIMIT = 30;
+
+export const listNotificationsForUser = async (
+  tx: Pick<PrismaClientTx, "notification">,
+  userId: string,
+) => {
+  const [notifications, unreadCount] = await Promise.all([
+    tx.notification.findMany({
+      where: { userId, deleted: null },
+      orderBy: { createdAt: "desc" },
+      take: NOTIFICATION_LIST_LIMIT,
+    }),
+    tx.notification.count({
+      where: { userId, deleted: null, readAt: null },
+    }),
+  ]);
+
+  return { notifications, unreadCount };
+};
+
+export const markNotificationRead = async (
+  tx: Pick<PrismaClientTx, "notification">,
+  userId: string,
+  id: string,
+) => {
+  const notification = await tx.notification.findFirst({
+    where: { id, userId, deleted: null },
+  });
+  if (!notification) {
+    throw new HttpError("Notification not found", 404);
+  }
+  if (notification.readAt) return notification;
+
+  return tx.notification.update({
+    where: { id },
+    data: { readAt: new Date() },
+  });
+};
+
+export const markAllNotificationsRead = async (
+  tx: Pick<PrismaClientTx, "notification">,
+  userId: string,
+): Promise<void> => {
+  await tx.notification.updateMany({
+    where: { userId, deleted: null, readAt: null },
+    data: { readAt: new Date() },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Persistence: turning evaluated targets into `Notification` rows, deduped.
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists whichever `targets` don't already exist (by `(userId, dedupeKey)`
+ * identity) and returns just the newly created ones. Combines the pure
+ * in-memory filter (`dedupeNotificationTargets`) with a DB read of existing
+ * identities for these exact users/keys, then relies on the
+ * `(userId, dedupeKey)` unique index (`skipDuplicates: true`) as the final
+ * backstop against a race between two concurrent evaluations.
+ */
+export const createDedupedNotifications = async (
+  tx: Pick<PrismaClientTx, "notification">,
+  targets: readonly NotificationTarget[],
+): Promise<NotificationTarget[]> => {
+  if (targets.length === 0) return [];
+
+  const existing = await tx.notification.findMany({
+    where: {
+      OR: targets.map((t) => ({
+        userId: t.userId,
+        dedupeKey: t.candidate.dedupeKey,
+      })),
+    },
+    select: { userId: true, dedupeKey: true },
+  });
+  const existingKeys = new Set(
+    existing.map((e) =>
+      notificationIdentityKey({
+        userId: e.userId,
+        candidate: { dedupeKey: e.dedupeKey } as NotificationCandidate,
+      }),
+    ),
+  );
+
+  const toCreate = dedupeNotificationTargets(targets, existingKeys);
+  if (toCreate.length === 0) return [];
+
+  await tx.notification.createMany({
+    data: toCreate.map((t) => ({
+      userId: t.userId,
+      type: t.candidate.type,
+      title: t.candidate.title,
+      body: t.candidate.body,
+      data: t.candidate.data as Prisma.InputJsonValue | undefined,
+      dedupeKey: t.candidate.dedupeKey,
+    })),
+    skipDuplicates: true,
+  });
+
+  return toCreate;
+};
+
+// ---------------------------------------------------------------------------
+// Push mirroring: for premium accounts, mirror newly created notifications
+// to every subscribed device. Best-effort — a push failure never rolls back
+// the in-app notification, which is the source of truth.
+// ---------------------------------------------------------------------------
+
+const sendPushForTargets = async (
+  tx: Pick<PrismaClientTx, "pushSubscription">,
+  targets: readonly NotificationTarget[],
+): Promise<void> => {
+  const userIds = [...new Set(targets.map((t) => t.userId))];
+  if (userIds.length === 0) return;
+
+  const subscriptions = await tx.pushSubscription.findMany({
+    where: { userId: { in: userIds } },
+  });
+  if (subscriptions.length === 0) return;
+
+  const subscriptionsByUser = new Map<string, typeof subscriptions>();
+  for (const sub of subscriptions) {
+    const list = subscriptionsByUser.get(sub.userId) ?? [];
+    list.push(sub);
+    subscriptionsByUser.set(sub.userId, list);
+  }
+
+  await Promise.all(
+    targets.map(async (target) => {
+      const subs = subscriptionsByUser.get(target.userId);
+      if (!subs || subs.length === 0) return;
+
+      await Promise.all(
+        subs.map(async (sub) => {
+          const keys = sub.keys as unknown as {
+            p256dh: string;
+            auth: string;
+          };
+          const result = await sendPushNotification(
+            { endpoint: sub.endpoint, keys },
+            {
+              title: target.candidate.title,
+              body: target.candidate.body,
+              type: target.candidate.type,
+              data: target.candidate.data,
+            },
+          );
+          if (result === "stale") {
+            await deletePushSubscriptionByEndpoint(tx, sub.endpoint);
+          }
+        }),
+      );
+    }),
+  );
+};
+
+/**
+ * Persists `targets` (deduped) and, for premium accounts, mirrors the newly
+ * created ones as web push. In-app creation is never gated by entitlements —
+ * only the push mirroring step checks `isPremium`, matching
+ * `canUsePushNotifications` (push subscriptions can only exist for premium
+ * accounts in the first place, but this is a defense-in-depth check against
+ * a since-downgraded account with stale subscriptions).
+ */
+const createAndPushNotifications = async (
+  tx: NotificationPrisma,
+  accountId: string,
+  targets: readonly NotificationTarget[],
+): Promise<NotificationTarget[]> => {
+  const created = await createDedupedNotifications(tx, targets);
+  if (created.length === 0) return created;
+
+  const account = await getAccountEntitlements(tx, accountId);
+  if (isPremium(account)) {
+    await sendPushForTargets(tx, created);
+  }
+
+  return created;
+};
+
+// ---------------------------------------------------------------------------
+// Trigger (a) + (b): evaluated together per account, since both only apply
+// to that account's ACTIVE budgets. Called from the cron route
+// (src/app/api/cron/recurring/route.ts) alongside recurring posting.
+// ---------------------------------------------------------------------------
+
+interface NotifiableMember {
+  userId: string;
+  categoryThreshold: boolean;
+  budgetPeriodEnding: boolean;
+}
+
+const getNotifiableMembers = async (
+  tx: Pick<PrismaClientTx, "accountUser">,
+  accountId: string,
+): Promise<NotifiableMember[]> => {
+  const accountUsers = await tx.accountUser.findMany({
+    where: { accountId },
+    select: { user: { select: { id: true, notificationSettings: true } } },
+  });
+
+  return accountUsers.map(({ user }) => {
+    const settings = parseNotificationSettings(user.notificationSettings);
+    return {
+      userId: user.id,
+      categoryThreshold: settings.categoryThreshold,
+      budgetPeriodEnding: settings.budgetPeriodEnding,
+    };
+  });
+};
+
+/**
+ * Evaluates triggers (a) "category >= 90% of its allocation" and (b)
+ * "budget period ends within 3 days" for every ACTIVE budget on the account,
+ * fans matching candidates out to every member with that trigger enabled,
+ * and persists (deduped) + pushes (premium) the result.
+ *
+ * No-ops entirely (before touching any budget data) when the account has the
+ * `notifications` feature toggle off — that's the master switch a household
+ * admin controls from Settings → Features, and it overrides every per-user
+ * trigger preference below it.
+ */
+export const evaluateBudgetNotificationsForAccount = async (
+  tx: NotificationPrisma,
+  accountId: string,
+  now: Date = new Date(),
+): Promise<NotificationTarget[]> => {
+  const account = await tx.account.findUnique({
+    where: { id: accountId },
+    select: { featureSettings: true },
+  });
+  if (!account) return [];
+
+  const featureSettings = parseFeatureSettings(account.featureSettings);
+  if (!featureSettings.notifications) return [];
+
+  const members = await getNotifiableMembers(tx, accountId);
+  if (members.length === 0) return [];
+
+  const budgets = await tx.budget.findMany({
+    where: { accountId, deleted: null, status: "ACTIVE" },
+    select: {
+      id: true,
+      name: true,
+      endAt: true,
+      categories: {
+        where: { deleted: null },
+        select: {
+          id: true,
+          name: true,
+          allocatedAmount: true,
+          transactions: {
+            where: { deleted: null },
+            select: {
+              transactionType: true,
+              amount: true,
+              cardId: true,
+              createdAt: true,
+              occurredAt: true,
+            },
+          },
+          transactionSplits: {
+            where: { transaction: { deleted: null } },
+            select: {
+              amount: true,
+              transaction: {
+                select: {
+                  transactionType: true,
+                  amount: true,
+                  cardId: true,
+                  createdAt: true,
+                  occurredAt: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const categoryThresholdCandidates: NotificationCandidate[] = [];
+  const periodEndingCandidates: NotificationCandidate[] = [];
+
+  for (const budget of budgets) {
+    const periodEnding = evaluateBudgetPeriodEnding({
+      budgetId: budget.id,
+      budgetName: budget.name,
+      endAt: budget.endAt,
+      now,
+    });
+    if (periodEnding) periodEndingCandidates.push(periodEnding);
+
+    for (const category of budget.categories) {
+      const spent = calculateCategorySpent(category);
+      const thresholdCandidate = evaluateCategoryThreshold({
+        categoryId: category.id,
+        categoryName: category.name,
+        budgetId: budget.id,
+        allocatedAmount: category.allocatedAmount,
+        spent,
+      });
+      if (thresholdCandidate) {
+        categoryThresholdCandidates.push(thresholdCandidate);
+      }
+    }
+  }
+
+  const targets: NotificationTarget[] = [];
+  for (const member of members) {
+    if (member.categoryThreshold) {
+      for (const candidate of categoryThresholdCandidates) {
+        targets.push({ userId: member.userId, candidate });
+      }
+    }
+    if (member.budgetPeriodEnding) {
+      for (const candidate of periodEndingCandidates) {
+        targets.push({ userId: member.userId, candidate });
+      }
+    }
+  }
+
+  return createAndPushNotifications(tx, accountId, targets);
+};
+
+// ---------------------------------------------------------------------------
+// Trigger (c): a recurring transaction was posted. Fired inline from
+// `postDueOccurrencesForTemplate` (lib/api-services/recurring.ts) right
+// after the `Transaction` row is created, scoped to that template's owner
+// (the account member who created the recurring transaction) rather than
+// every account member — it's their template posting, not a shared event.
+// ---------------------------------------------------------------------------
+
+export const notifyRecurringPosted = async (
+  tx: NotificationPrisma,
+  accountId: string,
+  userId: string,
+  candidate: NotificationCandidate,
+): Promise<void> => {
+  const account = await tx.account.findUnique({
+    where: { id: accountId },
+    select: { featureSettings: true },
+  });
+  if (
+    !account ||
+    !parseFeatureSettings(account.featureSettings).notifications
+  ) {
+    return;
+  }
+
+  const userSettings = await tx.accountUser.findFirst({
+    where: { accountId, userId },
+    select: { user: { select: { notificationSettings: true } } },
+  });
+  if (!userSettings) return;
+
+  const settings = parseNotificationSettings(
+    userSettings.user.notificationSettings,
+  );
+  if (!settings.recurringPosted) return;
+
+  await createAndPushNotifications(tx, accountId, [{ userId, candidate }]);
+};

--- a/lib/api-services/push.ts
+++ b/lib/api-services/push.ts
@@ -1,0 +1,51 @@
+import type { Prisma } from "@prisma/client";
+import type { PrismaClientTx } from "../prisma";
+import type { CreatePushSubscriptionSchema } from "../api-schemas/push";
+
+type PushPrisma = Pick<PrismaClientTx, "pushSubscription">;
+
+/**
+ * Registers (or re-registers) a browser's push subscription for a user.
+ * `endpoint` is globally unique per the Push API spec, so re-subscribing the
+ * same device/browser — even from a different account — upserts rather than
+ * violating the unique constraint; the `userId` on the row always tracks
+ * whoever most recently subscribed from that browser.
+ */
+export const upsertPushSubscription = async (
+  tx: PushPrisma,
+  userId: string,
+  data: CreatePushSubscriptionSchema,
+) =>
+  tx.pushSubscription.upsert({
+    where: { endpoint: data.endpoint },
+    create: {
+      userId,
+      endpoint: data.endpoint,
+      keys: data.keys as Prisma.InputJsonValue,
+    },
+    update: {
+      userId,
+      keys: data.keys as Prisma.InputJsonValue,
+    },
+  });
+
+/**
+ * Removes a subscription. Scoped to `userId` so a user can only unsubscribe
+ * their own devices; a no-op (not an error) if it's already gone.
+ */
+export const deletePushSubscription = async (
+  tx: PushPrisma,
+  userId: string,
+  endpoint: string,
+): Promise<void> => {
+  await tx.pushSubscription.deleteMany({ where: { userId, endpoint } });
+};
+
+/** Removes a subscription by endpoint alone — used when a push send comes
+ * back stale (404/410), where we only know the endpoint, not the owner. */
+export const deletePushSubscriptionByEndpoint = async (
+  tx: PushPrisma,
+  endpoint: string,
+): Promise<void> => {
+  await tx.pushSubscription.deleteMany({ where: { endpoint } });
+};

--- a/lib/api-services/recurring.ts
+++ b/lib/api-services/recurring.ts
@@ -13,6 +13,8 @@ import {
   previewUpcomingOccurrences,
   type BudgetWindow,
 } from "../utils/recurring";
+import { evaluateRecurringPosted } from "../utils/notifications";
+import { notifyRecurringPosted } from "./notifications";
 
 const recurringInclude = {
   category: {
@@ -223,6 +225,21 @@ export const postDueOccurrencesForTemplate = async (
           recurringTransactionId: template.id,
         },
       });
+
+      // Trigger (c) — see lib/utils/notifications.ts. Fired only on an
+      // actual new post (not the idempotency-backstop skip above), scoped to
+      // the template's owner rather than every account member.
+      await notifyRecurringPosted(
+        tx,
+        template.accountId,
+        template.userId,
+        evaluateRecurringPosted({
+          recurringTransactionId: template.id,
+          name: template.name,
+          amount: template.amount,
+          occurredAt: occurrenceDate,
+        }),
+      );
     }
     posted++;
 

--- a/lib/data-hooks/notifications/useNotificationSettings.ts
+++ b/lib/data-hooks/notifications/useNotificationSettings.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+} from "../services/notification-settings";
+import { DEFAULT_NOTIFICATION_SETTINGS } from "@/lib/types/notification-settings";
+
+export const notificationSettingsKey = [
+  "users",
+  "notification-settings",
+] as const;
+
+/** The current user's own per-trigger notification preferences. */
+export const useNotificationSettings = () => {
+  const { data: session } = useSession();
+
+  return useQuery({
+    queryKey: notificationSettingsKey,
+    queryFn: getNotificationSettings,
+    enabled: !!session,
+    staleTime: 60 * 1000,
+  });
+};
+
+/** Convenience default while loading, matching `DEFAULT_NOTIFICATION_SETTINGS`. */
+export const useNotificationSettingsOrDefault = () => {
+  const { data, ...rest } = useNotificationSettings();
+  return { data: data ?? DEFAULT_NOTIFICATION_SETTINGS, ...rest };
+};
+
+export const useUpdateNotificationSettings = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateNotificationSettings,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationSettingsKey });
+    },
+  });
+};

--- a/lib/data-hooks/notifications/useNotifications.ts
+++ b/lib/data-hooks/notifications/useNotifications.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import {
+  getNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "../services/notifications";
+
+export const notificationsKey = ["notifications"] as const;
+
+/**
+ * Recent notifications + unread count for the bell icon and dropdown list.
+ * Polls every 60s so the badge updates without a manual refresh (cron only
+ * runs daily, but recurring-posted notifications can land any time a
+ * template is caught up — see useRecurringCatchUp).
+ */
+export const useNotifications = () => {
+  const { data: session } = useSession();
+
+  return useQuery({
+    queryKey: notificationsKey,
+    queryFn: getNotifications,
+    enabled: !!session,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+};
+
+export const useMarkNotificationRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markNotificationRead,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsKey });
+    },
+  });
+};
+
+export const useMarkAllNotificationsRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllNotificationsRead,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsKey });
+    },
+  });
+};

--- a/lib/data-hooks/notifications/usePushSubscription.ts
+++ b/lib/data-hooks/notifications/usePushSubscription.ts
@@ -1,0 +1,52 @@
+import { useMutation } from "@tanstack/react-query";
+import { env } from "@/env";
+import { subscribeToPush, unsubscribeFromPush } from "../services/push";
+import {
+  getExistingPushSubscription,
+  subscribeBrowserToPush,
+} from "@/lib/utils/push-client";
+
+/**
+ * Subscribes this browser to push: asks the browser for a `PushSubscription`
+ * via the service worker already registered for the PWA (see public/sw.js),
+ * then registers it with the server. The server call is PREMIUM-gated (see
+ * POST /api/notifications/push) — free accounts get an `UpgradeRequiredError`
+ * (via `parseErrorResponse`) that callers should catch to open `UpgradeModal`.
+ */
+export const useSubscribeToPush = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const vapidPublicKey = env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+      if (!vapidPublicKey) {
+        throw new Error("Push notifications aren't configured for this app.");
+      }
+
+      const subscription = await subscribeBrowserToPush(vapidPublicKey);
+      const json = subscription.toJSON();
+      if (!json.endpoint || !json.keys?.p256dh || !json.keys.auth) {
+        throw new Error("Failed to create a push subscription.");
+      }
+
+      await subscribeToPush({
+        endpoint: json.endpoint,
+        keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+      });
+
+      return subscription;
+    },
+  });
+};
+
+/** Tears down this browser's push subscription, both server-side and in the
+ * browser itself. A no-op (not an error) if there's nothing to unsubscribe. */
+export const useUnsubscribeFromPush = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const subscription = await getExistingPushSubscription();
+      if (!subscription) return;
+
+      await unsubscribeFromPush(subscription.endpoint);
+      await subscription.unsubscribe();
+    },
+  });
+};

--- a/lib/data-hooks/services/notification-settings.ts
+++ b/lib/data-hooks/services/notification-settings.ts
@@ -1,0 +1,21 @@
+import type { NotificationSettings } from "@/lib/types/notification-settings";
+import { parseErrorResponse } from "./http";
+
+export const getNotificationSettings =
+  async (): Promise<NotificationSettings> => {
+    const response = await fetch("/api/users/notification-settings");
+    if (!response.ok) return parseErrorResponse(response);
+    return response.json() as Promise<NotificationSettings>;
+  };
+
+export const updateNotificationSettings = async (
+  patch: Partial<NotificationSettings>,
+): Promise<NotificationSettings> => {
+  const response = await fetch("/api/users/notification-settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<NotificationSettings>;
+};

--- a/lib/data-hooks/services/notifications.ts
+++ b/lib/data-hooks/services/notifications.ts
@@ -1,0 +1,28 @@
+import type {
+  NotificationListResponse,
+  SerializedNotification,
+} from "@/lib/types/notification";
+import { parseErrorResponse } from "./http";
+
+export const getNotifications = async (): Promise<NotificationListResponse> => {
+  const response = await fetch("/api/notifications");
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<NotificationListResponse>;
+};
+
+export const markNotificationRead = async (
+  id: string,
+): Promise<SerializedNotification> => {
+  const response = await fetch(`/api/notifications/${id}`, {
+    method: "PATCH",
+  });
+  if (!response.ok) return parseErrorResponse(response);
+  return response.json() as Promise<SerializedNotification>;
+};
+
+export const markAllNotificationsRead = async (): Promise<void> => {
+  const response = await fetch("/api/notifications/read-all", {
+    method: "POST",
+  });
+  if (!response.ok) return parseErrorResponse(response);
+};

--- a/lib/data-hooks/services/push.ts
+++ b/lib/data-hooks/services/push.ts
@@ -1,0 +1,29 @@
+import { parseErrorResponse } from "./http";
+
+export interface PushSubscriptionJSON {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+export const subscribeToPush = async (
+  subscription: PushSubscriptionJSON,
+): Promise<void> => {
+  const response = await fetch("/api/notifications/push", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(subscription),
+  });
+  if (!response.ok) return parseErrorResponse(response);
+};
+
+export const unsubscribeFromPush = async (endpoint: string): Promise<void> => {
+  const response = await fetch("/api/notifications/push", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ endpoint }),
+  });
+  if (!response.ok) return parseErrorResponse(response);
+};

--- a/lib/types/feature-settings.ts
+++ b/lib/types/feature-settings.ts
@@ -2,11 +2,11 @@ import { z } from "zod";
 
 /**
  * All toggleable/reserved module keys. `savings`, `cards`,
- * `aiReceiptScanning`, and `recurringTransactions` have UI/API wired today
- * (see `lib/utils/features.ts` and the Features tab on `/settings`).
- * `notifications` and `bankSync` are reserved for modules that don't exist
- * yet — keeping them here now means turning them on later is a UI change,
- * not a schema migration.
+ * `aiReceiptScanning`, `recurringTransactions`, and `notifications` have
+ * UI/API wired today (see `lib/utils/features.ts` and the Features tab on
+ * `/settings`). `bankSync` is reserved for a module that doesn't exist yet —
+ * keeping it here now means turning it on later is a UI change, not a schema
+ * migration.
  */
 export const FEATURE_KEYS = [
   "savings",
@@ -77,10 +77,9 @@ export interface ToggleableModule {
 }
 
 /**
- * Modules with a toggle in the Features settings UI today. Reserved keys
- * (`notifications`, `bankSync`) are intentionally excluded until their
- * features ship — showing a toggle for something that doesn't exist yet
- * would be confusing.
+ * Modules with a toggle in the Features settings UI today. `bankSync` is
+ * intentionally excluded until that feature ships — showing a toggle for
+ * something that doesn't exist yet would be confusing.
  */
 export const TOGGLEABLE_MODULES: readonly ToggleableModule[] = [
   {
@@ -102,5 +101,11 @@ export const TOGGLEABLE_MODULES: readonly ToggleableModule[] = [
     key: "recurringTransactions",
     label: "Recurring transactions",
     description: "Auto-post repeating transactions like rent and bills.",
+  },
+  {
+    key: "notifications",
+    label: "Notifications",
+    description:
+      "Get alerted about budget thresholds, period endings, and recurring transactions.",
   },
 ];

--- a/lib/types/notification-settings.ts
+++ b/lib/types/notification-settings.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+/**
+ * Per-user notification trigger preferences (see `User.notificationSettings`
+ * in prisma/schema.prisma). Distinct from the account-wide `notifications`
+ * feature toggle in `lib/types/feature-settings.ts`, which is the MASTER
+ * switch — when the account has `notifications` disabled the whole section
+ * is off for every member regardless of these per-user preferences (see
+ * `useFeatureSettings` + the Notifications settings tab).
+ */
+export const NOTIFICATION_TRIGGER_KEYS = [
+  "categoryThreshold",
+  "budgetPeriodEnding",
+  "recurringPosted",
+] as const;
+
+export type NotificationTriggerKey = (typeof NOTIFICATION_TRIGGER_KEYS)[number];
+
+export const notificationSettingsSchema = z.object({
+  categoryThreshold: z.boolean(),
+  budgetPeriodEnding: z.boolean(),
+  recurringPosted: z.boolean(),
+});
+
+export type NotificationSettings = z.infer<typeof notificationSettingsSchema>;
+
+/** Every trigger starts enabled — toggles are opt-out, not opt-in. */
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  categoryThreshold: true,
+  budgetPeriodEnding: true,
+  recurringPosted: true,
+};
+
+/**
+ * Parses a user's stored `notificationSettings` JSON into a complete
+ * `NotificationSettings` object. Merges over `DEFAULT_NOTIFICATION_SETTINGS`
+ * key by key, exactly like `parseFeatureSettings`: `null` (never configured)
+ * resolves to all-defaults, missing/malformed keys fall back individually,
+ * and this never throws.
+ */
+export const parseNotificationSettings = (
+  json: unknown,
+): NotificationSettings => {
+  const source =
+    json !== null && typeof json === "object" && !Array.isArray(json)
+      ? (json as Record<string, unknown>)
+      : {};
+
+  const result = { ...DEFAULT_NOTIFICATION_SETTINGS };
+  for (const key of NOTIFICATION_TRIGGER_KEYS) {
+    const value = source[key];
+    if (typeof value === "boolean") {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+/** Metadata for a trigger toggle rendered on the Notifications settings tab. */
+export interface NotificationTriggerToggle {
+  key: NotificationTriggerKey;
+  label: string;
+  description: string;
+}
+
+export const NOTIFICATION_TRIGGERS: readonly NotificationTriggerToggle[] = [
+  {
+    key: "categoryThreshold",
+    label: "Category nearing budget",
+    description: "When a category reaches 90% of its allocated amount.",
+  },
+  {
+    key: "budgetPeriodEnding",
+    label: "Budget period ending",
+    description: "When your active budget period ends within 3 days.",
+  },
+  {
+    key: "recurringPosted",
+    label: "Recurring transaction posted",
+    description: "When a recurring transaction is automatically posted.",
+  },
+];

--- a/lib/types/notification.ts
+++ b/lib/types/notification.ts
@@ -1,0 +1,34 @@
+import type { Notification } from "@prisma/client";
+
+/** A `Notification` row as returned by the API — dates serialized to ISO
+ * strings via `NextResponse.json`, matching the pattern in `lib/types/budget.ts`. */
+export type SerializedNotification = Omit<
+  Notification,
+  "createdAt" | "readAt" | "deleted"
+> & {
+  createdAt: string;
+  readAt: string | null;
+  deleted: string | null;
+};
+
+export interface NotificationListResponse {
+  notifications: SerializedNotification[];
+  unreadCount: number;
+}
+
+/** Shape of `Notification.data` for each trigger type, as populated by the
+ * `evaluate*` functions in `lib/utils/notifications.ts` — used by the bell
+ * dropdown to route a click to the right page. */
+export interface CategoryOverThresholdData {
+  categoryId: string;
+  budgetId: string;
+}
+
+export interface BudgetPeriodEndingData {
+  budgetId: string;
+}
+
+export interface RecurringPostedData {
+  recurringTransactionId: string;
+  occurredAt: string;
+}

--- a/lib/utils/entitlements.test.ts
+++ b/lib/utils/entitlements.test.ts
@@ -8,6 +8,7 @@ import {
   canInviteMember,
   canScanReceipt,
   canSplitTransactions,
+  canUsePushNotifications,
   canViewReportHistory,
   isBudgetLocked,
   isPocketLocked,
@@ -155,6 +156,28 @@ describe("canScanReceipt", () => {
     expect(canScanReceipt(account({ complimentaryAccess: true })).allowed).toBe(
       true,
     );
+  });
+});
+
+describe("canUsePushNotifications", () => {
+  it("denies a FREE account, with an upgrade reason", () => {
+    const result = canUsePushNotifications(account());
+    expect(result.allowed).toBe(false);
+    expect(!result.allowed && result.reason).toMatch(/premium/i);
+  });
+
+  it("allows a premium account", () => {
+    expect(
+      canUsePushNotifications(
+        account({ plan: "PREMIUM", subscriptionStatus: "ACTIVE" }),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("allows a complimentary account even on the FREE plan", () => {
+    expect(
+      canUsePushNotifications(account({ complimentaryAccess: true })).allowed,
+    ).toBe(true);
   });
 });
 

--- a/lib/utils/entitlements.ts
+++ b/lib/utils/entitlements.ts
@@ -209,6 +209,24 @@ export const canImportTransactions = (
   };
 };
 
+/**
+ * Whether the account may register a web-push subscription. Free accounts
+ * are in-app only; premium (or comped) accounts additionally get push. This
+ * only gates CREATING a `PushSubscription` (see the subscribe route) —
+ * in-app `Notification` rows are never gated by entitlements.
+ */
+export const canUsePushNotifications = (
+  account: AccountEntitlementFields,
+): CheckResult => {
+  if (isPremium(account)) return { allowed: true };
+
+  return {
+    allowed: false,
+    reason:
+      "Push notifications are a Premium feature. Upgrade to Premium to get alerts outside the app.",
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Downgrade locking
 //

--- a/lib/utils/notifications.test.ts
+++ b/lib/utils/notifications.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUDGET_PERIOD_ENDING_WINDOW_DAYS,
+  CATEGORY_SPEND_THRESHOLD_RATIO,
+  dedupeNotificationTargets,
+  evaluateBudgetPeriodEnding,
+  evaluateCategoryThreshold,
+  evaluateRecurringPosted,
+  notificationIdentityKey,
+  type NotificationTarget,
+} from "@/lib/utils/notifications";
+
+describe("evaluateCategoryThreshold", () => {
+  const base = {
+    categoryId: "cat_1",
+    categoryName: "Groceries",
+    budgetId: "budget_1",
+    allocatedAmount: 100,
+    spent: 0,
+  };
+
+  it("returns null when spend is below the threshold", () => {
+    expect(evaluateCategoryThreshold({ ...base, spent: 89.99 })).toBeNull();
+  });
+
+  it("fires at exactly the threshold ratio", () => {
+    const result = evaluateCategoryThreshold({
+      ...base,
+      spent: 100 * CATEGORY_SPEND_THRESHOLD_RATIO,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("CATEGORY_OVER_THRESHOLD");
+  });
+
+  it("fires when spend exceeds the allocated amount", () => {
+    const result = evaluateCategoryThreshold({ ...base, spent: 150 });
+    expect(result).not.toBeNull();
+    expect(result?.body).toContain("150%");
+  });
+
+  it("returns null when there is no allocation", () => {
+    expect(
+      evaluateCategoryThreshold({ ...base, allocatedAmount: null, spent: 500 }),
+    ).toBeNull();
+  });
+
+  it("returns null when the allocation is zero or negative", () => {
+    expect(
+      evaluateCategoryThreshold({ ...base, allocatedAmount: 0, spent: 10 }),
+    ).toBeNull();
+    expect(
+      evaluateCategoryThreshold({ ...base, allocatedAmount: -50, spent: 10 }),
+    ).toBeNull();
+  });
+
+  it("derives a dedupe key scoped to the category only", () => {
+    const result = evaluateCategoryThreshold({ ...base, spent: 95 });
+    expect(result?.dedupeKey).toBe("CATEGORY_OVER_THRESHOLD:cat_1");
+  });
+
+  it("is idempotent — evaluating the same input twice yields the same key", () => {
+    const first = evaluateCategoryThreshold({ ...base, spent: 95 });
+    const second = evaluateCategoryThreshold({ ...base, spent: 95 });
+    expect(first?.dedupeKey).toEqual(second?.dedupeKey);
+  });
+
+  it("derives different keys for different categories", () => {
+    const a = evaluateCategoryThreshold({ ...base, spent: 95 });
+    const b = evaluateCategoryThreshold({
+      ...base,
+      categoryId: "cat_2",
+      spent: 95,
+    });
+    expect(a?.dedupeKey).not.toEqual(b?.dedupeKey);
+  });
+});
+
+describe("evaluateBudgetPeriodEnding", () => {
+  const now = new Date("2026-07-06T00:00:00Z");
+  const base = {
+    budgetId: "budget_1",
+    budgetName: "July budget",
+    now,
+  };
+
+  it("returns null when the period ends further out than the window", () => {
+    const endAt = new Date(now.getTime());
+    endAt.setUTCDate(endAt.getUTCDate() + BUDGET_PERIOD_ENDING_WINDOW_DAYS + 1);
+    expect(evaluateBudgetPeriodEnding({ ...base, endAt })).toBeNull();
+  });
+
+  it("fires exactly at the edge of the window", () => {
+    const endAt = new Date(now.getTime());
+    endAt.setUTCDate(endAt.getUTCDate() + BUDGET_PERIOD_ENDING_WINDOW_DAYS);
+    const result = evaluateBudgetPeriodEnding({ ...base, endAt });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("BUDGET_PERIOD_ENDING");
+  });
+
+  it("fires when the period ends today", () => {
+    const result = evaluateBudgetPeriodEnding({ ...base, endAt: now });
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null once the period has already ended", () => {
+    const endAt = new Date(now.getTime());
+    endAt.setUTCDate(endAt.getUTCDate() - 1);
+    expect(evaluateBudgetPeriodEnding({ ...base, endAt })).toBeNull();
+  });
+
+  it("derives a dedupe key scoped to the budget only", () => {
+    const result = evaluateBudgetPeriodEnding({ ...base, endAt: now });
+    expect(result?.dedupeKey).toBe("BUDGET_PERIOD_ENDING:budget_1");
+  });
+});
+
+describe("evaluateRecurringPosted", () => {
+  it("always returns a candidate", () => {
+    const result = evaluateRecurringPosted({
+      recurringTransactionId: "rec_1",
+      name: "Rent",
+      amount: 1200,
+      occurredAt: new Date("2026-07-01T00:00:00Z"),
+    });
+    expect(result.type).toBe("RECURRING_POSTED");
+    expect(result.body).toContain("Rent");
+  });
+
+  it("falls back to a generic name when none is set", () => {
+    const result = evaluateRecurringPosted({
+      recurringTransactionId: "rec_1",
+      name: null,
+      amount: 50,
+      occurredAt: new Date("2026-07-01T00:00:00Z"),
+    });
+    expect(result.body).toContain("A recurring transaction");
+  });
+
+  it("derives a dedupe key scoped to the template and occurrence date", () => {
+    const occurredAt = new Date("2026-07-01T00:00:00Z");
+    const first = evaluateRecurringPosted({
+      recurringTransactionId: "rec_1",
+      name: "Rent",
+      amount: 1200,
+      occurredAt,
+    });
+    const second = evaluateRecurringPosted({
+      recurringTransactionId: "rec_1",
+      name: "Rent",
+      amount: 1200,
+      occurredAt,
+    });
+    expect(first.dedupeKey).toEqual(second.dedupeKey);
+
+    const laterOccurrence = evaluateRecurringPosted({
+      recurringTransactionId: "rec_1",
+      name: "Rent",
+      amount: 1200,
+      occurredAt: new Date("2026-08-01T00:00:00Z"),
+    });
+    expect(laterOccurrence.dedupeKey).not.toEqual(first.dedupeKey);
+  });
+});
+
+describe("dedupeNotificationTargets", () => {
+  const makeTarget = (
+    userId: string,
+    dedupeKey: string,
+  ): NotificationTarget => ({
+    userId,
+    candidate: {
+      type: "CATEGORY_OVER_THRESHOLD",
+      title: "t",
+      body: "b",
+      dedupeKey,
+    },
+  });
+
+  it("drops targets whose identity already exists", () => {
+    const targets = [makeTarget("u1", "k1"), makeTarget("u1", "k2")];
+    const existing = new Set([notificationIdentityKey(targets[0]!)]);
+
+    const result = dedupeNotificationTargets(targets, existing);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.candidate.dedupeKey).toBe("k2");
+  });
+
+  it("collapses duplicate targets within the same batch", () => {
+    const targets = [
+      makeTarget("u1", "k1"),
+      makeTarget("u1", "k1"),
+      makeTarget("u2", "k1"),
+    ];
+
+    const result = dedupeNotificationTargets(targets, new Set());
+
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.userId).sort()).toEqual(["u1", "u2"]);
+  });
+
+  it("is a no-op when nothing exists and there are no duplicates", () => {
+    const targets = [makeTarget("u1", "k1"), makeTarget("u2", "k1")];
+    const result = dedupeNotificationTargets(targets, new Set());
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns an empty array when every target already exists", () => {
+    const targets = [makeTarget("u1", "k1")];
+    const existing = new Set([notificationIdentityKey(targets[0]!)]);
+    expect(dedupeNotificationTargets(targets, existing)).toEqual([]);
+  });
+});

--- a/lib/utils/notifications.ts
+++ b/lib/utils/notifications.ts
@@ -1,0 +1,213 @@
+import type { NotificationType } from "@prisma/client";
+import { formatCurrency } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Pure, framework-agnostic trigger-evaluation + dedupe logic for in-app/push
+// notifications. Nothing here touches Prisma or the network — see
+// `lib/api-services/notifications.ts` for the DB-backed service that calls
+// into these helpers (evaluated in the cron route for (a)/(b), inline in the
+// recurring-posting service for (c) — see that file's module doc).
+// ---------------------------------------------------------------------------
+
+/** A category reaches this share of its allocated amount before it notifies. */
+export const CATEGORY_SPEND_THRESHOLD_RATIO = 0.9;
+
+/** A budget period notifies once it's this many days (or fewer) from ending. */
+export const BUDGET_PERIOD_ENDING_WINDOW_DAYS = 3;
+
+/**
+ * A notification ready to persist, minus the `userId` it targets (a single
+ * candidate is often fanned out to every account member — see
+ * `NotificationTarget`). `dedupeKey` is the stable event-identity: the same
+ * underlying event always derives the same key, so re-evaluating an
+ * already-notified event is a safe no-op (see `dedupeNotificationTargets`
+ * and the `(userId, dedupeKey)` unique index on `Notification`).
+ */
+export interface NotificationCandidate {
+  type: NotificationType;
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+  dedupeKey: string;
+}
+
+/** Joins a type with its identifying parts into a stable, human-readable key. */
+const buildDedupeKey = (type: NotificationType, ...parts: string[]): string =>
+  [type, ...parts].join(":");
+
+// ---------------------------------------------------------------------------
+// Trigger (a): a category has reached >= 90% of its allocated amount.
+// ---------------------------------------------------------------------------
+
+export interface CategoryThresholdInput {
+  categoryId: string;
+  categoryName: string;
+  budgetId: string;
+  /** Category.allocatedAmount — nullable/absent categories never trigger. */
+  allocatedAmount: number | null | undefined;
+  /** Spend for this category, as computed by `calculateCategorySpent`. */
+  spent: number;
+}
+
+/**
+ * Fires once a category's spend reaches `CATEGORY_SPEND_THRESHOLD_RATIO` of
+ * its allocated amount. Returns `null` when the category has no (or a
+ * non-positive) allocation, or spend hasn't reached the threshold yet.
+ *
+ * The dedupe key is scoped to the category alone (not the budget too)
+ * because a `Category` row already belongs to a single budget period — once
+ * that budget ends the category is never re-evaluated, so no separate period
+ * identifier is needed to keep the key unique across periods.
+ */
+export const evaluateCategoryThreshold = (
+  input: CategoryThresholdInput,
+): NotificationCandidate | null => {
+  const allocated = input.allocatedAmount;
+  if (allocated == null || allocated <= 0) return null;
+  if (input.spent / allocated < CATEGORY_SPEND_THRESHOLD_RATIO) return null;
+
+  const percent = Math.round((input.spent / allocated) * 100);
+
+  return {
+    type: "CATEGORY_OVER_THRESHOLD",
+    title: `${input.categoryName} is nearing its budget`,
+    body: `You've used ${percent}% of the ${formatCurrency(allocated)} allocated to ${input.categoryName}.`,
+    data: { categoryId: input.categoryId, budgetId: input.budgetId },
+    dedupeKey: buildDedupeKey("CATEGORY_OVER_THRESHOLD", input.categoryId),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Trigger (b): a budget period ends within 3 days.
+// ---------------------------------------------------------------------------
+
+export interface BudgetPeriodEndingInput {
+  budgetId: string;
+  budgetName: string;
+  endAt: Date;
+  now: Date;
+}
+
+/**
+ * Fires once a budget's `endAt` is within `BUDGET_PERIOD_ENDING_WINDOW_DAYS`
+ * days of `now` (inclusive), but not after it has already ended — a budget
+ * that already ended is handled by the budget-status lifecycle, not this
+ * notification. The dedupe key is scoped to the budget alone: a given
+ * `Budget` row has exactly one `endAt`, so it can only ever enter the window
+ * once.
+ */
+export const evaluateBudgetPeriodEnding = (
+  input: BudgetPeriodEndingInput,
+): NotificationCandidate | null => {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const daysUntilEnd = (input.endAt.getTime() - input.now.getTime()) / msPerDay;
+
+  if (daysUntilEnd < 0 || daysUntilEnd > BUDGET_PERIOD_ENDING_WINDOW_DAYS) {
+    return null;
+  }
+
+  return {
+    type: "BUDGET_PERIOD_ENDING",
+    title: `${input.budgetName} ends soon`,
+    body: `Your budget period ends on ${input.endAt.toLocaleDateString(
+      "en-US",
+      {
+        month: "short",
+        day: "numeric",
+      },
+    )}.`,
+    data: { budgetId: input.budgetId },
+    dedupeKey: buildDedupeKey("BUDGET_PERIOD_ENDING", input.budgetId),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Trigger (c): a recurring transaction was posted.
+// ---------------------------------------------------------------------------
+
+export interface RecurringPostedInput {
+  recurringTransactionId: string;
+  name: string | null | undefined;
+  amount: number;
+  occurredAt: Date;
+}
+
+/**
+ * Always fires (posting is itself the event) — dedupe is what keeps it to
+ * once per occurrence: the key includes both the template id and the
+ * occurrence date, matching the `(recurringTransactionId, occurredAt)`
+ * uniqueness the posting engine already guarantees for the `Transaction`
+ * row itself (see `lib/utils/recurring.ts`).
+ */
+export const evaluateRecurringPosted = (
+  input: RecurringPostedInput,
+): NotificationCandidate => {
+  const trimmedName = input.name?.trim();
+  const displayName =
+    trimmedName && trimmedName.length > 0
+      ? trimmedName
+      : "A recurring transaction";
+
+  return {
+    type: "RECURRING_POSTED",
+    title: "Recurring transaction posted",
+    body: `${displayName} for ${formatCurrency(input.amount)} was posted.`,
+    data: {
+      recurringTransactionId: input.recurringTransactionId,
+      occurredAt: input.occurredAt.toISOString(),
+    },
+    dedupeKey: buildDedupeKey(
+      "RECURRING_POSTED",
+      input.recurringTransactionId,
+      input.occurredAt.toISOString(),
+    ),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Dedupe: fanning a candidate out to users, then filtering out anything
+// already notified.
+// ---------------------------------------------------------------------------
+
+/** A candidate notification aimed at a specific user. */
+export interface NotificationTarget {
+  userId: string;
+  candidate: NotificationCandidate;
+}
+
+/**
+ * The identity of a (user, event) pair — matches the `(userId, dedupeKey)`
+ * unique index on `Notification`. Two targets with the same identity key
+ * represent the same notification and must collapse to one.
+ */
+export const notificationIdentityKey = (
+  target: Pick<NotificationTarget, "userId" | "candidate">,
+): string => `${target.userId}:${target.candidate.dedupeKey}`;
+
+/**
+ * Filters `targets` down to the ones that haven't already fired, given the
+ * identity keys (`notificationIdentityKey`) of notifications that already
+ * exist (typically loaded from the DB for just these users/keys — see
+ * `lib/api-services/notifications.ts`). Also collapses duplicate targets
+ * within the same batch, so a caller that (for example) evaluates the same
+ * category twice in one pass never double-submits it.
+ *
+ * Pure and order-preserving; the DB's unique index remains the ultimate
+ * backstop against a race between two concurrent evaluations.
+ */
+export const dedupeNotificationTargets = (
+  targets: readonly NotificationTarget[],
+  existingIdentityKeys: ReadonlySet<string>,
+): NotificationTarget[] => {
+  const seen = new Set(existingIdentityKeys);
+  const result: NotificationTarget[] = [];
+
+  for (const target of targets) {
+    const key = notificationIdentityKey(target);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(target);
+  }
+
+  return result;
+};

--- a/lib/utils/push-client.ts
+++ b/lib/utils/push-client.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// Browser-only helpers for the web-push subscribe/unsubscribe flow (Feature 5
+// — Notifications, PREMIUM tier). Nothing here is unit-testable business
+// logic — it's thin wrapping over `navigator`/`window` — so it isn't covered
+// by the notifications test suite; see `lib/utils/notifications.ts` for the
+// pure trigger/dedupe logic that is.
+// ---------------------------------------------------------------------------
+
+/** Whether this browser can support web push at all. */
+export const isPushSupported = (): boolean =>
+  typeof window !== "undefined" &&
+  "serviceWorker" in navigator &&
+  "PushManager" in window &&
+  "Notification" in window;
+
+const isIosDevice = (): boolean =>
+  typeof navigator !== "undefined" &&
+  /iphone|ipad|ipod/i.test(navigator.userAgent);
+
+/** True when the app is running installed to the home screen (standalone
+ * display mode), on any platform. */
+export const isStandalonePwa = (): boolean => {
+  if (typeof window === "undefined") return false;
+  const displayModeStandalone =
+    window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+  // iOS Safari's legacy (non-standard) standalone flag.
+  const iosStandaloneFlag =
+    (navigator as unknown as { standalone?: boolean }).standalone === true;
+  return displayModeStandalone || iosStandaloneFlag;
+};
+
+/**
+ * True when push is unsupported specifically because this is iOS Safari
+ * running in a regular browser tab rather than installed to the home
+ * screen — iOS 16.4+ only supports web push from the installed PWA. The
+ * settings UI shows a hint instead of a broken toggle in this case.
+ */
+export const needsIosHomeScreenInstall = (): boolean =>
+  isIosDevice() && !isStandalonePwa();
+
+/** Converts a URL-safe base64 VAPID public key into the Uint8Array shape
+ * `PushManager.subscribe` expects for `applicationServerKey`. */
+export const urlBase64ToUint8Array = (base64String: string): Uint8Array => {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+};
+
+/** The current push subscription for this browser, if any (across app
+ * reloads — the browser/service worker remembers it, not our server). */
+export const getExistingPushSubscription =
+  async (): Promise<PushSubscription | null> => {
+    if (!isPushSupported()) return null;
+    const registration = await navigator.serviceWorker.ready;
+    return registration.pushManager.getSubscription();
+  };
+
+/** Subscribes this browser to push via the already-registered service
+ * worker (see public/sw.js), using the app's public VAPID key. */
+export const subscribeBrowserToPush = async (
+  vapidPublicKey: string,
+): Promise<PushSubscription> => {
+  const registration = await navigator.serviceWorker.ready;
+  return registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+  });
+};

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "resend": "^6.17.1",
     "stripe": "^22.3.0",
     "tailwind-merge": "^3.3.1",
+    "web-push": "^3.6.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -57,6 +58,7 @@
     "@types/node": "^20.14.10",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.17",
     "bcryptjs": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.24.2
         version: 3.25.57
@@ -93,6 +96,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.1.6(@types/react@19.1.7)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.3(@types/node@20.19.0)(jiti@2.4.2)(tsx@4.19.4)(yaml@2.8.0))
@@ -1038,6 +1044,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@8.34.0':
     resolution: {integrity: sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1234,6 +1243,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1309,6 +1322,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1353,6 +1369,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bn.js@4.12.4:
+    resolution: {integrity: sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -1367,6 +1386,9 @@ packages:
     resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1577,6 +1599,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.166:
     resolution: {integrity: sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==}
@@ -1932,6 +1957,14 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1957,6 +1990,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2144,6 +2180,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2283,6 +2325,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2764,6 +2809,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -2771,6 +2819,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -3181,6 +3232,11 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -3944,6 +4000,10 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.0
+
   '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -4141,6 +4201,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4244,6 +4306,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.4
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -4278,6 +4347,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bn.js@4.12.4: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -4297,6 +4368,8 @@ snapshots:
       electron-to-chromium: 1.5.166
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4489,6 +4562,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.166: {}
 
@@ -5011,6 +5088,15 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  http_ece@1.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5027,6 +5113,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5236,6 +5324,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5340,6 +5439,8 @@ snapshots:
       picomatch: 2.3.1
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -5756,6 +5857,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -5766,6 +5869,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
     dependencies:
@@ -6252,6 +6357,16 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@8.0.1: {}
 

--- a/prisma/migrations/20260706172754_add_notifications/migration.sql
+++ b/prisma/migrations/20260706172754_add_notifications/migration.sql
@@ -1,0 +1,59 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('CATEGORY_OVER_THRESHOLD', 'BUDGET_PERIOD_ENDING', 'RECURRING_POSTED');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "notificationSettings" JSONB;
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "data" JSONB,
+    "dedupeKey" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "deleted" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "push_subscriptions" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "keys" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "push_subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_idx" ON "notifications"("userId");
+
+-- CreateIndex
+CREATE INDEX "notifications_type_idx" ON "notifications"("type");
+
+-- CreateIndex
+CREATE INDEX "notifications_readAt_idx" ON "notifications"("readAt");
+
+-- CreateIndex
+CREATE INDEX "notifications_deleted_idx" ON "notifications"("deleted");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "notifications_userId_dedupeKey_key" ON "notifications"("userId", "dedupeKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "push_subscriptions_endpoint_key" ON "push_subscriptions"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "push_subscriptions_userId_idx" ON "push_subscriptions"("userId");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "push_subscriptions" ADD CONSTRAINT "push_subscriptions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,16 @@ model User {
   savings               Savings[]
   allocations           Allocation[]
   recurringTransactions RecurringTransaction[]
+  notifications         Notification[]
+  pushSubscriptions     PushSubscription[]
+  // Per-user notification trigger preferences (see
+  // lib/types/notification-settings.ts). JSON, like `Account.featureSettings`,
+  // so adding a new trigger later doesn't require a migration. Null means
+  // "never configured" — callers must merge over
+  // DEFAULT_NOTIFICATION_SETTINGS via parseNotificationSettings, never read
+  // raw. Distinct from the account-wide `notifications` feature toggle,
+  // which is the master on/off switch this only refines.
+  notificationSettings  Json?
 
   @@index([email])
   @@index([name])
@@ -287,6 +297,56 @@ model RecurringTransaction {
   @@map("recurring_transactions")
 }
 
+// An in-app notification for a single user, created by the trigger-evaluation
+// logic in lib/utils/notifications.ts (pure) + lib/api-services/notifications.ts
+// (persistence). FREE accounts get these in-app only; PREMIUM accounts with an
+// active `PushSubscription` also get a web push mirroring the same content.
+//
+// `dedupeKey` is the stable event-identity the trigger derives (e.g.
+// `CATEGORY_OVER_THRESHOLD:{categoryId}` or
+// `RECURRING_POSTED:{recurringTransactionId}:{occurredAt}`) — the
+// `(userId, dedupeKey)` unique index is the DB-level backstop that makes each
+// event fire at most once per user, even if the evaluator runs twice
+// concurrently (see `dedupeNotificationTargets` for the in-memory pre-filter).
+model Notification {
+  id        String           @id @default(cuid())
+  userId    String
+  user      User             @relation(fields: [userId], references: [id])
+  type      NotificationType
+  title     String
+  body      String
+  data      Json?
+  dedupeKey String
+  readAt    DateTime?
+  deleted   DateTime?
+  createdAt DateTime         @default(now())
+
+  @@unique([userId, dedupeKey])
+  @@index([userId])
+  @@index([type])
+  @@index([readAt])
+  @@index([deleted])
+  @@map("notifications")
+}
+
+// A browser's web-push registration for a user (one row per device/browser).
+// Creation is Premium-gated (see `canUsePushNotifications` in
+// lib/utils/entitlements.ts); free accounts stay in-app only. `endpoint` is
+// globally unique per the Push API spec, so re-subscribing the same
+// device/browser upserts rather than duplicating.
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  endpoint  String   @unique
+  // `{ p256dh, auth }` keys from the browser's PushSubscription.toJSON().
+  keys      Json
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@map("push_subscriptions")
+}
+
 model Savings {
   id        String    @id @default(cuid())
   name      String
@@ -401,6 +461,15 @@ enum SubscriptionStatus {
 enum EmailTokenPurpose {
   PASSWORD_RESET
   LOGIN_CODE
+}
+
+// Trigger kinds the notification evaluator can fire (see
+// lib/utils/notifications.ts). Adding a new trigger means adding a variant
+// here plus a pure `evaluate*` function — no other schema change needed.
+enum NotificationType {
+  CATEGORY_OVER_THRESHOLD
+  BUDGET_PERIOD_ENDING
+  RECURRING_POSTED
 }
 
 model EmailToken {

--- a/public/sw.js
+++ b/public/sw.js
@@ -88,3 +88,72 @@ self.addEventListener("fetch", (event) => {
     }),
   );
 });
+
+// ---------------------------------------------------------------------------
+// Web push (Feature 5 — Notifications, PREMIUM tier). The payload shape
+// (`{ title, body, type, data }`) is built by lib/api-services/notifications.ts
+// via src/server/push.ts — see those for what `type`/`data` hold per trigger.
+// ---------------------------------------------------------------------------
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    return;
+  }
+
+  const title = payload.title || "Ronin";
+  const options = {
+    body: payload.body || "",
+    icon: "/android-chrome-192x192.png",
+    badge: "/android-chrome-192x192.png",
+    data: { type: payload.type, ...payload.data },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+// Resolves the page a push notification should open. Mirrors
+// components/notifications/notificationLink.ts — kept in sync manually,
+// since a plain (unbundled) service worker can't import the app's TS.
+function resolveNotificationUrl(data) {
+  if (!data) return "/";
+
+  switch (data.type) {
+    case "CATEGORY_OVER_THRESHOLD":
+      return data.budgetId ? `/budgets/${data.budgetId}/categories` : "/";
+    case "BUDGET_PERIOD_ENDING":
+      return data.budgetId ? `/budgets/${data.budgetId}` : "/";
+    case "RECURRING_POSTED":
+      return "/transactions/recurring";
+    default:
+      return "/";
+  }
+}
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = resolveNotificationUrl(event.notification.data);
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if (
+            new URL(client.url).origin === self.location.origin &&
+            "focus" in client
+          ) {
+            if ("navigate" in client) client.navigate(url);
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(url);
+        }
+      }),
+  );
+});

--- a/src/app/api/cron/recurring/route.ts
+++ b/src/app/api/cron/recurring/route.ts
@@ -2,12 +2,26 @@ import { type NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import prisma from "@/lib/prisma";
 import { postDueRecurringTransactionsForAccount } from "@/lib/api-services/recurring";
+import { evaluateBudgetNotificationsForAccount } from "@/lib/api-services/notifications";
 
 /**
- * Daily cron entry point (see vercel.json) that posts every due recurring
- * transaction across every account. Vercel Cron automatically sends
- * `Authorization: Bearer ${CRON_SECRET}` when the CRON_SECRET env var is set
- * (see src/env.js), so this route just verifies that header matches.
+ * Daily cron entry point (see vercel.json) that, per account: posts every due
+ * recurring transaction, then evaluates the two budget-driven notification
+ * triggers — "category >= 90% of its allocation" and "budget period ends
+ * within 3 days" (see lib/utils/notifications.ts). The third trigger,
+ * "recurring transaction posted", fires inline from
+ * `postDueRecurringTransactionsForAccount` itself as each occurrence posts.
+ *
+ * This route used to post recurring transactions only; folding the
+ * notification evaluation in here (rather than a separate route/cron
+ * schedule) is the lowest-churn option — same daily cadence, same
+ * per-account transaction, no new vercel.json entry. The name is now a
+ * slight misnomer but the path is unchanged to avoid touching vercel.json's
+ * schedule config and any external references to it.
+ *
+ * Vercel Cron automatically sends `Authorization: Bearer ${CRON_SECRET}` when
+ * the CRON_SECRET env var is set (see src/env.js), so this route just
+ * verifies that header matches.
  *
  * Each account is processed in its own `prisma.$transaction` (rather than one
  * transaction spanning every account) so a large account list can't hold one
@@ -28,20 +42,49 @@ export async function GET(req: NextRequest) {
 
   const now = new Date();
 
-  const dueAccounts = await prisma.recurringTransaction.findMany({
-    where: { deleted: null, paused: false, nextRunAt: { lte: now } },
-    distinct: ["accountId"],
-    select: { accountId: true },
-  });
+  // The account set to process is the union of "has a due recurring
+  // transaction" and "has an active budget" — the notification triggers
+  // apply to every active budget regardless of whether that account has any
+  // recurring transactions at all.
+  const [dueRecurringAccounts, activeBudgetAccounts] = await Promise.all([
+    prisma.recurringTransaction.findMany({
+      where: { deleted: null, paused: false, nextRunAt: { lte: now } },
+      distinct: ["accountId"],
+      select: { accountId: true },
+    }),
+    prisma.budget.findMany({
+      where: { deleted: null, status: "ACTIVE" },
+      distinct: ["accountId"],
+      select: { accountId: true },
+    }),
+  ]);
+
+  const accountIds = new Set([
+    ...dueRecurringAccounts.map((a) => a.accountId),
+    ...activeBudgetAccounts.map((a) => a.accountId),
+  ]);
 
   const results = [];
-  for (const { accountId } of dueAccounts) {
-    const summaries = await prisma.$transaction((tx) =>
-      postDueRecurringTransactionsForAccount(tx, accountId, now),
+  for (const accountId of accountIds) {
+    const { summaries, notifications } = await prisma.$transaction(
+      async (tx) => {
+        const summaries = await postDueRecurringTransactionsForAccount(
+          tx,
+          accountId,
+          now,
+        );
+        const notifications = await evaluateBudgetNotificationsForAccount(
+          tx,
+          accountId,
+          now,
+        );
+        return { summaries, notifications };
+      },
     );
     results.push({
       accountId,
       posted: summaries.reduce((sum, s) => sum + s.posted, 0),
+      notificationsCreated: notifications.length,
       summaries,
     });
   }
@@ -50,6 +93,10 @@ export async function GET(req: NextRequest) {
     {
       accountsProcessed: results.length,
       totalPosted: results.reduce((sum, r) => sum + r.posted, 0),
+      totalNotificationsCreated: results.reduce(
+        (sum, r) => sum + r.notificationsCreated,
+        0,
+      ),
       results,
     },
     { status: 200 },

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { markNotificationRead } from "@/lib/api-services/notifications";
+
+// PATCH /api/notifications/[id] — marks a single notification read. Scoped
+// to the current user's own notifications (404 for anyone else's).
+export const PATCH = withUser({
+  PATCH: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const { id } = await context.params;
+      const notification = await prisma.$transaction((tx) =>
+        markNotificationRead(tx, user.id, id!),
+      );
+      return NextResponse.json(notification, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/notifications/push/route.ts
+++ b/src/app/api/notifications/push/route.ts
@@ -1,0 +1,79 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import {
+  createPushSubscriptionSchema,
+  deletePushSubscriptionSchema,
+} from "@/lib/api-schemas/push";
+import {
+  deletePushSubscription,
+  upsertPushSubscription,
+} from "@/lib/api-services/push";
+import {
+  getAccountEntitlements,
+  paymentRequired,
+} from "@/lib/api-services/entitlements";
+import { canUsePushNotifications } from "@/lib/utils/entitlements";
+
+// POST /api/notifications/push — registers a browser's web-push subscription
+// for the current user. PREMIUM-gated: free accounts get a 402 with
+// `upgradeRequired: true` (never a throw — see paymentRequired) so the
+// client can open UpgradeModal instead of a generic error toast. In-app
+// notifications are never gated; only push registration is.
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = (await req.json()) as unknown;
+      const parsed = createPushSubscriptionSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { message: "Validation failed", errors: parsed.error.errors },
+          { status: 400 },
+        );
+      }
+
+      const account = await getAccountEntitlements(prisma, user.accountId);
+      const entitlementCheck = canUsePushNotifications(account);
+      if (!entitlementCheck.allowed) {
+        return paymentRequired(entitlementCheck.reason);
+      }
+
+      const subscription = await prisma.$transaction((tx) =>
+        upsertPushSubscription(tx, user.id, parsed.data),
+      );
+      return NextResponse.json(subscription, { status: 201 });
+    },
+  ),
+});
+
+// DELETE /api/notifications/push — unregisters a subscription. Never gated;
+// turning push off is always allowed regardless of plan.
+export const DELETE = withUser({
+  DELETE: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = (await req.json()) as unknown;
+      const parsed = deletePushSubscriptionSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { message: "Validation failed", errors: parsed.error.errors },
+          { status: 400 },
+        );
+      }
+
+      await prisma.$transaction((tx) =>
+        deletePushSubscription(tx, user.id, parsed.data.endpoint),
+      );
+      return NextResponse.json({ success: true }, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { markAllNotificationsRead } from "@/lib/api-services/notifications";
+
+// POST /api/notifications/read-all — marks every unread notification for the
+// current user as read (the bell dropdown's "mark all as read" action).
+export const POST = withUser({
+  POST: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      await prisma.$transaction((tx) => markAllNotificationsRead(tx, user.id));
+      return NextResponse.json({ success: true }, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,25 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { listNotificationsForUser } from "@/lib/api-services/notifications";
+
+// GET /api/notifications — the current user's recent in-app notifications
+// (never gated by entitlements; in-app is free for everyone) plus their
+// unread count, for the bell icon + dropdown list in the app chrome.
+export const GET = withUser({
+  GET: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const { notifications, unreadCount } = await listNotificationsForUser(
+        prisma,
+        user.id,
+      );
+      return NextResponse.json({ notifications, unreadCount }, { status: 200 });
+    },
+  ),
+});

--- a/src/app/api/users/notification-settings/route.ts
+++ b/src/app/api/users/notification-settings/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { withUser } from "@/lib/middleware/withUser";
+import { withUserErrorHandling } from "@/lib/middleware/withUserErrorHandling";
+import prisma from "@/lib/prisma";
+import type { User } from "@prisma/client";
+import { updateNotificationSettingsSchema } from "@/lib/api-schemas/notification-settings";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+} from "@/lib/api-services/notification-settings";
+
+// GET /api/users/notification-settings — the current user's own per-trigger
+// notification preferences (see lib/types/notification-settings.ts).
+// Distinct from the account-wide /api/account/feature-settings toggle.
+export const GET = withUser({
+  GET: withUserErrorHandling(
+    async (
+      _req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const settings = await getNotificationSettings(prisma, user.id);
+      return NextResponse.json(settings, { status: 200 });
+    },
+  ),
+});
+
+// PATCH /api/users/notification-settings — merges a subset of trigger
+// preferences over the user's existing settings. No admin check — these are
+// personal preferences, unlike the account-wide feature toggles.
+export const PATCH = withUser({
+  PATCH: withUserErrorHandling(
+    async (
+      req: NextRequest,
+      _context: { params: Promise<Record<string, string>> },
+      user: User & { accountId: string },
+    ) => {
+      const body = (await req.json()) as unknown;
+      const parsed = updateNotificationSettingsSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { message: "Validation failed", errors: parsed.error.errors },
+          { status: 400 },
+        );
+      }
+
+      const settings = await prisma.$transaction((tx) =>
+        updateNotificationSettings(tx, user.id, parsed.data),
+      );
+      return NextResponse.json(settings, { status: 200 });
+    },
+  ),
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -25,6 +25,7 @@ import {
   Palette,
   CreditCard,
   ToggleLeft,
+  Bell,
 } from "lucide-react";
 import Button from "@/components/Button";
 import { usePageLoading } from "@/components/ConditionalLayout";
@@ -32,6 +33,7 @@ import ThemeSelector from "@/components/settings/ThemeSelector";
 import PlanComparison from "@/components/billing/PlanComparison";
 import ChangePasswordForm from "@/components/settings/ChangePasswordForm";
 import FeatureToggles from "@/components/settings/FeatureToggles";
+import NotificationSettingsPanel from "@/components/settings/NotificationSettingsPanel";
 import { Role } from "@prisma/client";
 import { useUpdateProfile } from "@/lib/data-hooks/users/useUser";
 import {
@@ -41,6 +43,9 @@ import {
   billingStatusKey,
 } from "@/lib/data-hooks/billing/useBilling";
 import type { BillingInterval } from "@/lib/data-hooks/services/billing";
+import { useFeatureSettings } from "@/lib/data-hooks/accounts/useFeatureSettings";
+import { isFeatureEnabled } from "@/lib/utils/features";
+import { DEFAULT_FEATURE_SETTINGS } from "@/lib/types/feature-settings";
 
 interface AccountUser {
   id: string;
@@ -69,7 +74,9 @@ const SettingsPageContent = () => {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState(() => {
     const tab = searchParams.get("tab");
-    return tab === "billing" || tab === "features" ? tab : "profile";
+    return tab === "billing" || tab === "features" || tab === "notifications"
+      ? tab
+      : "profile";
   });
   const [isEditingProfile, setIsEditingProfile] = useState(false);
   const [showCreateUserModal, setShowCreateUserModal] = useState(false);
@@ -81,8 +88,22 @@ const SettingsPageContent = () => {
   const { data: billingStatus, isLoading: billingLoading } = useBillingStatus();
   const checkoutMutation = useCheckout();
   const portalMutation = useBillingPortal();
+  const { data: featureSettings } = useFeatureSettings();
+  const notificationsFeatureEnabled = isFeatureEnabled(
+    featureSettings ?? DEFAULT_FEATURE_SETTINGS,
+    "notifications",
+  );
 
   const isAdmin = session?.user?.role === Role.ADMIN;
+
+  // The account admin can turn the `notifications` feature toggle off while
+  // this tab is open (or a deep link points at it) — bounce back to Profile
+  // rather than showing a disabled section with nothing in it.
+  useEffect(() => {
+    if (activeTab === "notifications" && !notificationsFeatureEnabled) {
+      setActiveTab("profile");
+    }
+  }, [activeTab, notificationsFeatureEnabled]);
 
   // Handle the redirect back from Stripe Checkout: toast on success/cancel,
   // refresh billing status, and strip `checkout` from the URL so a refresh
@@ -188,9 +209,20 @@ const SettingsPageContent = () => {
     { id: "profile", label: "Profile", icon: UserIcon },
     { id: "preferences", label: "Preferences", icon: Palette },
     { id: "features", label: "Features", icon: ToggleLeft },
+  ];
+
+  // The notifications tab only exists while the household's `notifications`
+  // feature toggle is on — that toggle is the master switch (see
+  // lib/types/feature-settings.ts), so an off account never even sees the
+  // per-user trigger/push preferences underneath it.
+  if (notificationsFeatureEnabled) {
+    tabs.push({ id: "notifications", label: "Notifications", icon: Bell });
+  }
+
+  tabs.push(
     { id: "billing", label: "Billing", icon: CreditCard },
     { id: "security", label: "Security", icon: Shield },
-  ];
+  );
 
   // Add Users tab for admin users
   if (isAdmin) {
@@ -471,6 +503,12 @@ const SettingsPageContent = () => {
             <div className="space-y-4 sm:space-y-6">
               <FeatureToggles isAdmin={isAdmin} />
             </div>
+          )}
+
+          {/* Notifications Tab — only reachable while the account's
+              `notifications` feature toggle is on (see the tabs array above). */}
+          {activeTab === "notifications" && notificationsFeatureEnabled && (
+            <NotificationSettingsPanel />
           )}
 
           {/* Billing Tab */}

--- a/src/env.js
+++ b/src/env.js
@@ -46,6 +46,14 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
+    // Web push (Feature 5 — Notifications). Both optional so the app still
+    // builds/runs without push configured: in-app notifications work either
+    // way, and the push-sending helper (lib/server/push.ts) no-ops when
+    // these are unset rather than throwing. Generate a pair with
+    // `npx web-push generate-vapid-keys`.
+    VAPID_PRIVATE_KEY: z.string().optional(),
+    // Contact URI required by the Push spec, e.g. "mailto:support@example.com".
+    VAPID_SUBJECT: z.string().optional(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -57,7 +65,10 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
-    // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    // Public half of the VAPID key pair, used by the browser to subscribe to
+    // push (see lib/utils/push-client.ts). Optional so free/no-push builds
+    // don't need it — the settings UI hides the push toggle when it's unset.
+    NEXT_PUBLIC_VAPID_PUBLIC_KEY: z.string().optional(),
   },
 
   /**
@@ -81,6 +92,9 @@ export const env = createEnv({
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     EMAIL_FROM: process.env.EMAIL_FROM,
     CRON_SECRET: process.env.CRON_SECRET,
+    VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
+    VAPID_SUBJECT: process.env.VAPID_SUBJECT,
+    NEXT_PUBLIC_VAPID_PUBLIC_KEY: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
     NODE_ENV: process.env.NODE_ENV,
   },
   /**

--- a/src/server/push.ts
+++ b/src/server/push.ts
@@ -1,0 +1,89 @@
+import webPush from "web-push";
+import { env } from "@/env";
+
+/**
+ * Thin wrapper around the `web-push` library for sending web push
+ * notifications (Feature 5 — Notifications, PREMIUM tier). Configured
+ * lazily so importing this module never throws when VAPID keys are unset —
+ * push is simply a no-op and in-app notifications keep working (see
+ * `lib/api-services/notifications.ts`, which never blocks on this).
+ *
+ * Generate a key pair with `npx web-push generate-vapid-keys` and set
+ * `VAPID_PRIVATE_KEY` / `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (+ optionally
+ * `VAPID_SUBJECT`) to enable push in an environment.
+ */
+
+let configured = false;
+
+function ensureConfigured(): boolean {
+  if (!env.VAPID_PRIVATE_KEY || !env.NEXT_PUBLIC_VAPID_PUBLIC_KEY) {
+    return false;
+  }
+
+  if (!configured) {
+    webPush.setVapidDetails(
+      env.VAPID_SUBJECT ?? "mailto:support@ronin.app",
+      env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+      env.VAPID_PRIVATE_KEY,
+    );
+    configured = true;
+  }
+
+  return true;
+}
+
+export interface PushSubscriptionKeys {
+  p256dh: string;
+  auth: string;
+}
+
+export interface PushTarget {
+  endpoint: string;
+  keys: PushSubscriptionKeys;
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  /** Notification type (e.g. "BUDGET_PERIOD_ENDING") — the service worker's
+   * `notificationclick` handler switches on this to resolve a destination
+   * URL, mirroring components/notifications/notificationLink.ts. */
+  type?: string;
+  data?: Record<string, unknown>;
+}
+
+export type SendPushResult = "sent" | "skipped" | "stale";
+
+/**
+ * Sends a push notification to a single subscription.
+ * - `"sent"` — delivered to the push service.
+ * - `"skipped"` — VAPID isn't configured; not an error, just a no-op.
+ * - `"stale"` — the push service reported the subscription is gone
+ *   (404/410); the caller should delete the `PushSubscription` row.
+ */
+export async function sendPushNotification(
+  target: PushTarget,
+  payload: PushPayload,
+): Promise<SendPushResult> {
+  if (!ensureConfigured()) return "skipped";
+
+  try {
+    await webPush.sendNotification(
+      { endpoint: target.endpoint, keys: target.keys },
+      JSON.stringify(payload),
+    );
+    return "sent";
+  } catch (error) {
+    const statusCode =
+      typeof error === "object" && error !== null && "statusCode" in error
+        ? (error as { statusCode?: unknown }).statusCode
+        : undefined;
+
+    if (statusCode === 404 || statusCode === 410) {
+      return "stale";
+    }
+
+    console.error("Failed to send push notification", error);
+    return "skipped";
+  }
+}


### PR DESCRIPTION
## Feature 5 — Notifications

Stacked on #96 (Feature 4). FREE: in-app (bell + unread list). PREMIUM: web push. Builds on the existing PWA groundwork (`public/sw.js`, `site.webmanifest`).

### Schema (migration `add_notifications`)
- `Notification` (`userId`, `type` [`NotificationType`], `title`, `body`, `data Json?`, `dedupeKey`, `readAt`, soft-delete, `@@unique([userId, dedupeKey])`).
- `PushSubscription` (`userId`, `endpoint @unique`, `keys Json`).
- `User.notificationSettings Json?` (per-user, unlike the account-wide `featureSettings`).

### Triggers + dedupe (`lib/utils/notifications.ts`, 20 tests)
- (a) category ≥90% of allocated, (b) budget period ends ≤3 days, (c) recurring transaction posted.
- Dedupe: stable `dedupeKey` (`TYPE:entityId[:period]`) → `(userId, dedupeKey)` unique index; in-memory filter + DB re-check + `createMany({skipDuplicates:true})` backstop, so each event fires once.
- (a)+(b) run in the existing `/api/cron/recurring` route (extended, not renamed — keeps `vercel.json` untouched); (c) fires inline in the recurring posting service to the template owner. 90% threshold reuses `lib/utils/spending.ts`.

### Free vs premium
In-app creation never gated. `canUsePushNotifications` (entitlements + tests); `POST /api/notifications/push` returns 402 for free accounts (defense-in-depth `isPremium` re-check before sending). `web-push` added; `VAPID_PRIVATE_KEY`/`VAPID_SUBJECT` (server) + `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (client), all optional so the app runs without push configured.

### Master toggle + per-user settings
`notifications` added to `TOGGLEABLE_MODULES` (account-wide master switch via Feature 1). Every evaluation path short-circuits if the account toggle is off; per-user `NotificationSettings` refine which triggers fire underneath. New "Notifications" settings tab (hidden when the master toggle is off) with per-trigger toggles + push toggle + iOS home-screen-install hint (iOS 16.4+ standalone detection).

### UI
`NotificationBell` (dark in SideNav header, light in MobileHeader) + `NotificationPanel` (sheet modal, mark-read/mark-all). Shared `ToggleRow` extracted from Feature 1's `FeatureToggles`. `sw.js` extended with `push`/`notificationclick` (existing cache/fetch handlers preserved). New bell/panel pattern documented in DESIGN.md §10.

### Notes
- `.env.example` not updated with VAPID vars (was outside the agent's edit scope) — worth adding before deploy.
- Runtime push flow / SW handlers / bell rendering are typechecked + lint-clean but not exercised in a browser.

`pnpm check` clean; 196/196 tests pass; `prisma migrate status` up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)